### PR TITLE
[fix] use dkg-metadata for session-progress rpc

### DIFF
--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -148,7 +148,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("tangle-standalone"),
 	impl_name: create_runtime_str!("tangle-standalone"),
 	authoring_version: 1,
-	spec_version: 112, // v0.1.12
+	spec_version: 113, // v0.1.13
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
Changelog:
This was never updated, but started to cause issues after the latest reduction of SessionsPerEra. Previously the keys would be generated in under a block, but now with more validators the in process keygen would be killed.