### PR TITLE
chore: release `tangle-subxt` 0.5.0

### DIFF
--- a/tangle-subxt/Cargo.toml
+++ b/tangle-subxt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tangle-subxt"
-version = "0.4.0"
+version = "0.5.0"
 description = "Rust bindings and interface to interact with Tangle Network using subxt"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Bump `tangle-subxt` to 0.5.0
