### PR TITLE
chore: bump tangle-subxt in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14305,7 +14305,7 @@ dependencies = [
 
 [[package]]
 name = "tangle-subxt"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fix the version of `tangle-subxt` in Cargo.lock

missed this in #806
