### PR TITLE
fix: handle type checking for optionals

### DIFF
--- a/primitives/src/services/field.rs
+++ b/primitives/src/services/field.rs
@@ -295,7 +295,7 @@ pub enum FieldType {
 impl<C: Constraints, AccountId> PartialEq<FieldType> for Field<C, AccountId> {
 	fn eq(&self, other: &FieldType) -> bool {
 		match (self, other) {
-			(Self::None, FieldType::Optional(_)) => true,
+			(_, FieldType::Optional(ty)) => matches!(self, Self::None) || self == &**ty,
 			(Self::Bool(_), FieldType::Bool) => true,
 			(Self::Uint8(_), FieldType::Uint8) => true,
 			(Self::Int8(_), FieldType::Int8) => true,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- An optional field of any value other than `None` would fail type checking. Now it gets compared to `None` *or* the type of the optional.
