### PR TITLE
Fix typos 

### DIFF
--- a/frost/src/identifier.rs
+++ b/frost/src/identifier.rs
@@ -34,7 +34,7 @@ where
 	/// This feature is not part of the specification and is just a convenient
 	/// way of creating identifiers.
 	///
-	/// Each possible byte string will map to an uniformly random identifier.
+	/// Each possible byte string will map to a uniformly random identifier.
 	/// Returns an error if the ciphersuite does not support identifier derivation,
 	/// or if the mapped identifier is zero (which is unpredictable, but should happen
 	/// with negligible probability).

--- a/frost/src/keys.rs
+++ b/frost/src/keys.rs
@@ -133,7 +133,7 @@ impl<C> VerifyingShare<C>
 where
 	C: Ciphersuite,
 {
-	/// Create a new [`VerifyingShare`] from a element.
+	/// Create a new [`VerifyingShare`] from an element.
 	pub fn new(element: Element<C>) -> Self {
 		Self(element)
 	}

--- a/pallets/multi-asset-delegation/src/functions/deposit.rs
+++ b/pallets/multi-asset-delegation/src/functions/deposit.rs
@@ -112,7 +112,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	/// Schedules an withdraw request for a delegator.
+	/// Schedules a withdraw request for a delegator.
 	///
 	/// # Arguments
 	///
@@ -155,7 +155,7 @@ impl<T: Config> Pallet<T> {
 		})
 	}
 
-	/// Executes an withdraw request for a delegator.
+	/// Executes a withdraw request for a delegator.
 	///
 	/// # Arguments
 	///
@@ -226,7 +226,7 @@ impl<T: Config> Pallet<T> {
 		})
 	}
 
-	/// Cancels an withdraw request for a delegator.
+	/// Cancels a withdraw request for a delegator.
 	///
 	/// # Arguments
 	///


### PR DESCRIPTION
This pull request addresses minor typographical errors in the following files:
- `identifier.rs`: Corrected "an uniformly" to "a uniformly" for proper article usage.
- `keys.rs`: Fixed "an element" to "a element" in function documentation.
- `deposit.rs`: Fixed incorrect use of articles in multiple comments related to withdrawal requests.

These changes improve readability and adhere to grammatical conventions.

**Reference issue to close**: 
Closes #

---

### Checklist:
- [ ] I have read the contributing guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests to prove the changes are effective.
- [ ] I have updated the documentation accordingly. 
