### PR TITLE
chore!: fix MAD Precompile function names

### DIFF
--- a/precompiles/multi-asset-delegation/src/lib.rs
+++ b/precompiles/multi-asset-delegation/src/lib.rs
@@ -242,7 +242,7 @@ where
 		Ok(())
 	}
 
-	#[precompile::public("schedule_withdraw(uint256,address,uint256)")]
+	#[precompile::public("scheduleWithdraw(uint256,address,uint256)")]
 	fn schedule_withdraw(
 		handle: &mut impl PrecompileHandle,
 		asset_id: U256,
@@ -275,7 +275,7 @@ where
 		Ok(())
 	}
 
-	#[precompile::public("cancel_withdraw(uint256,address,uint256)")]
+	#[precompile::public("cancelWithdraw(uint256,address,uint256)")]
 	fn cancel_withdraw(
 		handle: &mut impl PrecompileHandle,
 		asset_id: U256,
@@ -351,7 +351,7 @@ where
 		Ok(())
 	}
 
-	#[precompile::public("schedule_delegator_unstake(bytes32,uint256,address,uint256)")]
+	#[precompile::public("scheduleDelegatorUnstake(bytes32,uint256,address,uint256)")]
 	fn schedule_delegator_unstake(
 		handle: &mut impl PrecompileHandle,
 		operator: H256,


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

This pull request includes changes to the `precompiles/multi-asset-delegation/src/lib.rs` file, focusing on renaming methods to follow camelCase naming conventions.

Method renaming for camelCase consistency:

* Renamed `schedule_withdraw` to `scheduleWithdraw` (`precompiles/multi-asset-delegation/src/lib.rs`)
* Renamed `cancel_withdraw` to `cancelWithdraw` (`precompiles/multi-asset-delegation/src/lib.rs`)
* Renamed `schedule_delegator_unstake` to `scheduleDelegatorUnstake` (`precompiles/multi-asset-delegation/src/lib.rs`)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
