### PR TITLE
fix: operator input in the MAD precompile `delegate` call

### DIFF
--- a/node/tests/evm_restaking.rs
+++ b/node/tests/evm_restaking.rs
@@ -399,7 +399,7 @@ fn operator_join_delegator_delegate_erc20() {
 
 		let delegate_result = precompile
 			.delegate(
-				alice.address().into_word(),
+				alice.address().to_account_id().0.into(),
 				U256::ZERO,
 				*usdc.address(),
 				delegate_amount,
@@ -498,7 +498,7 @@ fn operator_join_delegator_delegate_asset_id() {
 
 		let delegate_result = precompile
 			.delegate(
-				alice.address().into_word(),
+				alice.address().to_account_id().0.into(),
 				U256::from(t.usdc_asset_id),
 				Address::ZERO,
 				U256::from(delegate_amount),

--- a/precompiles/multi-asset-delegation/src/lib.rs
+++ b/precompiles/multi-asset-delegation/src/lib.rs
@@ -372,8 +372,7 @@ where
 
 		let caller = handle.context().caller;
 		let who = Runtime::AddressMapping::into_account_id(caller);
-		let operator =
-			Runtime::AddressMapping::into_account_id(H160::from_slice(&operator.0[12..]));
+		let operator = Runtime::AccountId::from(WrappedAccountId32(operator.0));
 
 		let (deposit_asset, amount) = match (asset_id.as_u128(), token_address.0 .0) {
 			(0, erc20_token) if erc20_token != [0; 20] => {

--- a/precompiles/multi-asset-delegation/src/tests.rs
+++ b/precompiles/multi-asset-delegation/src/tests.rs
@@ -260,6 +260,14 @@ fn test_delegate_assets() {
 			.execute_returns(());
 
 		assert_eq!(Assets::balance(1, delegator_account), 500 - 200); // no change when delegating
+		assert!(Operators::<Runtime>::get(operator_account)
+			.unwrap()
+			.delegations
+			.iter()
+			.find(|x| x.delegator == delegator_account
+				&& x.asset_id == Asset::Custom(1)
+				&& x.amount == 100)
+			.is_some());
 	});
 }
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
Improvements to account ID handling:

* [`precompiles/multi-asset-delegation/src/lib.rs`](diffhunk://#diff-f83d645597140bef38b54c199f4274b6fb122158244eb292919e30f068108c5eL375-R375): Modified the conversion of the operator address to use `WrappedAccountId32` instead of the truncating and remapping.

Enhancements to test assertions:

* [`precompiles/multi-asset-delegation/src/tests.rs`](diffhunk://#diff-bd2c758e64b73a03dfae4acc1569505b0ee16bdbe79edbe5d015a13cce8f043bR263-R270): Added assertions in the `test_delegate_assets` function to verify that the correct delegation entries are present in the `Operators` storage.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #881
