### PR TITLE
fix: prerelease CI

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -20,7 +20,7 @@ jobs:
         id: commit_info
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "commit_message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
+          echo "commit_message='$(git log -1 --pretty=%B)'" >> $GITHUB_OUTPUT
 
       # Generating a GitHub token, so that tags created by the action
       # triggers the other workflows


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- 
This pull request includes a minor change to the `.github/workflows/pre-release.yml` file. The change ensures that the commit message is correctly wrapped in single quotes when being set as an output variable.

* [`.github/workflows/pre-release.yml`](diffhunk://#diff-8f0c4d810b263ab478547020c847ee0297cc98c11c67fc2209ce604e52719607L23-R23): Wrapped the commit message in single quotes to handle cases where the message contains special characters or spaces.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
