### PR TITLE
feat: add slash alert for slashed erc20s

### DIFF
--- a/pallets/multi-asset-delegation/src/functions/evm.rs
+++ b/pallets/multi-asset-delegation/src/functions/evm.rs
@@ -256,11 +256,11 @@ impl<T: Config> Pallet<T> {
 		};
 		let weight = Self::weight_from_call_info(&info);
 
-		// decode the result and return it
-		let maybe_value = info.exit_reason.is_succeed().then_some(&info.value);
-		if maybe_value.is_none() {
-			return Err(Error::<T>::EVMAbiDecode.into());
+		// If the call failed, that's ok - the contract may not support onSlash
+		if !info.exit_reason.is_succeed() {
+			log::debug!(target: "evm", "Contract does not support onSlash method");
 		}
+
 		Ok((info, weight))
 	}
 

--- a/pallets/multi-asset-delegation/src/functions/evm.rs
+++ b/pallets/multi-asset-delegation/src/functions/evm.rs
@@ -197,6 +197,71 @@ impl<T: Config> Pallet<T> {
 		}
 	}
 
+	pub fn call_slash_alert(
+		from: H160,
+		to: H160,
+		blueprint_id: u64,
+		service_id: u64,
+		operator: [u8; 32],
+		slash_amount: U256,
+		gas_limit: u64,
+	) -> Result<fp_evm::CallInfo, DispatchErrorWithPostInfo> {
+		#[allow(deprecated)]
+		let slash_fn = Function {
+			name: String::from("onSlash"),
+			inputs: vec![
+				ethabi::Param {
+					name: String::from("blueprintId"),
+					kind: ethabi::ParamType::Uint(64),
+					internal_type: None,
+				},
+				ethabi::Param {
+					name: String::from("serviceId"),
+					kind: ethabi::ParamType::Uint(64),
+					internal_type: None,
+				},
+				ethabi::Param {
+					name: String::from("operator"),
+					kind: ethabi::ParamType::FixedBytes(32),
+					internal_type: None,
+				},
+				ethabi::Param {
+					name: String::from("slashAmount"),
+					kind: ethabi::ParamType::Uint(256),
+					internal_type: None,
+				},
+			],
+			outputs: vec![],
+			constant: None,
+			state_mutability: StateMutability::NonPayable,
+		};
+
+		let data = slash_fn.encode_input(&[
+			Token::Uint(blueprint_id.into()),
+			Token::Uint(service_id.into()),
+			Token::FixedBytes(operator.to_vec()),
+			Token::Uint(slash_amount.into()),
+		])?;
+
+		log::debug!(target: "evm", "Dispatching EVM call(0x{}): {}", hex::encode(slash_fn.short_signature()), slash_fn.signature());
+		let call_result = Self::evm_call(from, to, U256::zero(), data, gas_limit);
+		let info = match call_result {
+			Ok(info) => info,
+			Err(e) => {
+				log::debug!(target: "evm", "ERC20 Transfer Call failed: {:?}", e);
+				return Err(e);
+			},
+		};
+		let weight = Self::weight_from_call_info(&info);
+
+		// decode the result and return it
+		let maybe_value = info.exit_reason.is_succeed().then_some(&info.value);
+		if maybe_value.is_none() {
+			return Err(Error::<T>::EVMAbiDecode.into());
+		}
+		Ok(info)
+	}
+
 	/// Convert the gas used in the call info to weight.
 	pub fn weight_from_call_info(info: &fp_evm::CallInfo) -> Weight {
 		let mut gas_to_weight = T::EvmGasWeightMapping::gas_to_weight(

--- a/pallets/multi-asset-delegation/src/functions/slash.rs
+++ b/pallets/multi-asset-delegation/src/functions/slash.rs
@@ -24,6 +24,7 @@ use frame_support::{
 	},
 	weights::Weight,
 };
+use parity_scale_codec::Encode;
 use sp_runtime::{traits::CheckedSub, DispatchError};
 use tangle_primitives::services::EvmAddressMapping;
 use tangle_primitives::{
@@ -90,7 +91,7 @@ impl<T: Config> Pallet<T> {
 		unapplied_slash: &UnappliedSlash<T::AccountId>,
 		delegator: &T::AccountId,
 	) -> Result<Weight, DispatchError> {
-		let weight = T::DbWeight::get().reads(1);
+		let mut weight = T::DbWeight::get().reads(1);
 
 		Delegators::<T>::try_mutate(delegator, |maybe_metadata| -> DispatchResult {
 			let metadata = maybe_metadata.as_mut().ok_or(Error::<T>::NotDelegator)?;
@@ -124,17 +125,17 @@ impl<T: Config> Pallet<T> {
 
 			match delegation.asset {
 				Asset::Erc20(address) => {
-					let on_slash_call = Self::call_slash_alert(
-						&Self::pallet_evm_account(),
+					let (_, _weight) = Self::call_slash_alert(
+						Self::pallet_evm_account(),
 						address,
 						unapplied_slash.blueprint_id,
 						unapplied_slash.service_id,
-						unapplied_slash.operator,
+						unapplied_slash.operator.encode().try_into().unwrap_or_default(),
 						slash_amount,
-					);
-					let (success, _weight) =
-						on_slash_call.map_err(|_| Error::<T>::ERC20TransferFailed)?;
-					ensure!(success, Error::<T>::ERC20TransferFailed);
+						500_000,
+					)
+					.map_err(|_| Error::<T>::SlashAlertFailed)?;
+					weight += _weight;
 				},
 				Asset::Custom(_) => {
 					// No custom asset handling for now
@@ -173,7 +174,7 @@ impl<T: Config> Pallet<T> {
 		asset: Asset<T::AssetId>,
 		slash_amount: BalanceOf<T>,
 	) -> Result<Weight, DispatchError> {
-		let weight: Weight = Weight::zero();
+		let mut weight: Weight = Weight::zero();
 
 		match asset {
 			Asset::Custom(asset_id) => {
@@ -197,6 +198,8 @@ impl<T: Config> Pallet<T> {
 				)
 				.map_err(|_| Error::<T>::ERC20TransferFailed)?;
 				ensure!(success, Error::<T>::ERC20TransferFailed);
+
+				weight += _weight;
 			},
 		}
 

--- a/pallets/multi-asset-delegation/src/lib.rs
+++ b/pallets/multi-asset-delegation/src/lib.rs
@@ -492,6 +492,8 @@ pub mod pallet {
 		BlueprintNotSelected,
 		/// Erc20 transfer failed
 		ERC20TransferFailed,
+		/// Slash alert failed
+		SlashAlertFailed,
 		/// EVM encode error
 		EVMAbiEncode,
 		/// EVM decode error


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- When an ERC20 is slashed we don't know if it's from cross-chain restaking. Nonetheless, we call this fn.
