### PR TITLE
chore(types): Bump types to manual release v0.9.18

### DIFF
--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tangle-network/tangle-substrate-types",
-	"version": "0.9.17",
+	"version": "0.9.18",
 	"description": "Polkadot.js type definitions required for interacting with Tangle's tangle network",
 	"author": "Tangle Developers <drew@tangle.network>",
 	"license": "Apache-2.0",


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

- Manually bump `types` version in Github to address previous CI release failure due to outdated git history.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes `NaN`.