### PR TITLE
feat: Blueprint Manager Updates

### DIFF
--- a/node/src/blueprint_service.rs
+++ b/node/src/blueprint_service.rs
@@ -13,15 +13,20 @@ pub fn create_blueprint_manager_service<P: AsRef<Path>>(
 	rpc_port: u16,
 	data_dir: P,
 	local_keystore: Arc<LocalKeystore>,
+	test_mode: bool,
 ) -> Result<BlueprintManagerHandle, ServiceError> {
+	let data_dir = data_dir.as_ref().to_path_buf();
+	let base_dir = data_dir.parent().ok_or_else(|| {
+		ServiceError::Application("Failed to get parent directory for keystore".into())
+	})?;
 	let config = BlueprintManagerConfig {
 		gadget_config: None,
-		keystore_uri: data_dir.as_ref().display().to_string(),
-		data_dir: data_dir.as_ref().to_path_buf(),
+		keystore_uri: base_dir.join("keystore").to_path_buf().to_string_lossy().into(),
+		data_dir,
 		verbose: 2,
 		pretty: false,
 		instance_id: None,
-		test_mode: false,
+		test_mode,
 	};
 	let mut env = BlueprintEnvironment::default();
 

--- a/node/src/manual_seal.rs
+++ b/node/src/manual_seal.rs
@@ -527,6 +527,8 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 	let config_data_path = config.data_path.clone();
 	#[cfg(feature = "blueprint-manager")]
 	let rpc_port = config.rpc_port;
+	#[cfg(feature = "blueprint-manager")]
+	let chain_type = config.chain_spec.chain_type();
 	let params = sc_service::SpawnTasksParams {
 		network: network.clone(),
 		client: client.clone(),
@@ -625,10 +627,12 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 		#[cfg(feature = "blueprint-manager")]
 		{
 			log::info!("Blueprint Manager is enabled.");
+			let test_mode = chain_type == ChainType::Development || chain_type == ChainType::Local;
 			let bp_mngr = crate::blueprint_service::create_blueprint_manager_service(
 				rpc_port,
 				config_data_path.join("blueprints"),
 				keystore_container.local_keystore(),
+				test_mode,
 			)?;
 
 			task_manager
@@ -689,10 +693,12 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 	#[cfg(feature = "blueprint-manager")]
 	{
 		log::info!("Blueprint Manager is enabled.");
+		let test_mode = chain_type == ChainType::Development || chain_type == ChainType::Local;
 		let bp_mngr = crate::blueprint_service::create_blueprint_manager_service(
 			rpc_port,
 			config_data_path.join("blueprints"),
 			keystore_container.local_keystore(),
+			test_mode,
 		)?;
 
 		task_manager

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -530,6 +530,8 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 	let config_data_path = config.data_path.clone();
 	#[cfg(feature = "blueprint-manager")]
 	let rpc_port = config.rpc_port;
+	#[cfg(feature = "blueprint-manager")]
+	let chain_type = config.chain_spec.chain_type();
 	let params = sc_service::SpawnTasksParams {
 		network: network.clone(),
 		client: client.clone(),
@@ -653,10 +655,12 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 
 	#[cfg(feature = "blueprint-manager")]
 	{
+		let test_mode = chain_type == ChainType::Development || chain_type == ChainType::Local;
 		let bp_mngr = crate::blueprint_service::create_blueprint_manager_service(
 			rpc_port,
 			config_data_path.join("blueprints"),
 			keystore_container.local_keystore(),
+			test_mode,
 		)?;
 
 		task_manager


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
This pull request introduces changes to the blueprint manager service and its initialization process to support a new `test_mode` parameter. The changes ensure that the blueprint manager can be configured differently based on the chain type.

Key changes include:

### Blueprint Service Enhancements:
* Added a `test_mode` parameter to the `create_blueprint_manager_service` function in `node/src/blueprint_service.rs`. This parameter is used to configure the blueprint manager based on the chain type.

### Initialization Adjustments:
* Updated the `new_full` function in `node/src/manual_seal.rs` to pass the `test_mode` parameter when creating the blueprint manager service. The `test_mode` is determined based on the chain type. [[1]](diffhunk://#diff-bd5e4092850dbce14435fbf9909d500d6b21d17ddc7aa1a70c05b884381db815R530-R531) [[2]](diffhunk://#diff-bd5e4092850dbce14435fbf9909d500d6b21d17ddc7aa1a70c05b884381db815R630-R635) [[3]](diffhunk://#diff-bd5e4092850dbce14435fbf9909d500d6b21d17ddc7aa1a70c05b884381db815R696-R701)
* Similarly, updated the `new_full` function in `node/src/service.rs` to include the `test_mode` parameter for the blueprint manager service initialization. [[1]](diffhunk://#diff-594440db8adfc5d1b37711309312bfa06b49e488309186ad062a896778cf9fbfR533-R534) [[2]](diffhunk://#diff-594440db8adfc5d1b37711309312bfa06b49e488309186ad062a896778cf9fbfR658-R663)



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
