### PR TITLE
Implement result type checker

### DIFF
--- a/pallets/services/src/tests/jobs.rs
+++ b/pallets/services/src/tests/jobs.rs
@@ -465,11 +465,11 @@ fn test_invalid_result_formats() {
 			Services::submit_result(RuntimeOrigin::signed(bob.clone()), 0, 0, bounded_vec![
 				Field::String("invalid".try_into().unwrap())
 			],),
-			Error::<Runtime>::TypeCheck(TypeCheckError::ArgumentTypeMismatch {
-				index: 0,
-				expected: FieldType::List(Box::new(FieldType::String)),
-				actual: FieldType::String,
-			}),
+                        Error::<Runtime>::TypeCheck(TypeCheckError::ResultTypeMismatch {
+                                index: 0,
+                                expected: FieldType::List(Box::new(FieldType::String)),
+                                actual: FieldType::String,
+                        }),
 		);
 	});
 }

--- a/primitives/src/services/jobs.rs
+++ b/primitives/src/services/jobs.rs
@@ -133,15 +133,15 @@ pub enum JobResultVerifier {
 
 /// Type checks the supplied arguments against the parameters.
 pub fn type_checker<C: Constraints, AccountId: Encode + Clone>(
-	params: &[FieldType],
-	args: &[Field<C, AccountId>],
+        params: &[FieldType],
+        args: &[Field<C, AccountId>],
 ) -> Result<(), TypeCheckError> {
-	if params.len() != args.len() {
-		return Err(TypeCheckError::NotEnoughArguments {
-			expected: params.len() as u8,
-			actual: args.len() as u8,
-		});
-	}
+        if params.len() != args.len() {
+                return Err(TypeCheckError::NotEnoughArguments {
+                        expected: params.len() as u8,
+                        actual: args.len() as u8,
+                });
+        }
 	for i in 0..args.len() {
 		let arg = &args[i];
 		let expected = &params[i];
@@ -156,6 +156,31 @@ pub fn type_checker<C: Constraints, AccountId: Encode + Clone>(
 	Ok(())
 }
 
+/// Type checks result fields against the expected result types.
+pub fn result_type_checker<C: Constraints, AccountId: Encode + Clone>(
+        result: &[FieldType],
+        fields: &[Field<C, AccountId>],
+) -> Result<(), TypeCheckError> {
+        if result.len() != fields.len() {
+                return Err(TypeCheckError::NotEnoughArguments {
+                        expected: result.len() as u8,
+                        actual: fields.len() as u8,
+                });
+        }
+        for i in 0..fields.len() {
+                let field = &fields[i];
+                let expected = &result[i];
+                if field != expected {
+                        return Err(TypeCheckError::ResultTypeMismatch {
+                                index: i as u8,
+                                expected: expected.clone(),
+                                actual: field.clone().into(),
+                        });
+                }
+        }
+        Ok(())
+}
+
 impl<C: Constraints, AccountId: Encode + Clone> JobCall<C, AccountId> {
 	/// Check if the supplied arguments match the job definition types.
 	pub fn type_check(&self, job_def: &JobDefinition<C>) -> Result<(), TypeCheckError> {
@@ -164,8 +189,8 @@ impl<C: Constraints, AccountId: Encode + Clone> JobCall<C, AccountId> {
 }
 
 impl<C: Constraints, AccountId: Encode + Clone> JobCallResult<C, AccountId> {
-	/// Check if the supplied result match the job definition types.
-	pub fn type_check(&self, job_def: &JobDefinition<C>) -> Result<(), TypeCheckError> {
-		type_checker(&job_def.result, &self.result)
-	}
+        /// Check if the supplied result match the job definition types.
+        pub fn type_check(&self, job_def: &JobDefinition<C>) -> Result<(), TypeCheckError> {
+                result_type_checker(&job_def.result, &self.result)
+        }
 }


### PR DESCRIPTION
## Summary
- handle result mismatch errors using `ResultTypeMismatch`
- adjust job tests for new error variant

## Testing
- `cargo nextest run --workspace --exclude tangle --profile ci` *(fails: could not download file)*