### PR TITLE
Update all tests/mocks

### DIFF
--- a/pallets/claims/src/mock.rs
+++ b/pallets/claims/src/mock.rs
@@ -77,6 +77,7 @@ impl pallet_balances::Config for Test {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {

--- a/pallets/credits/src/mock.rs
+++ b/pallets/credits/src/mock.rs
@@ -96,6 +96,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = RuntimeHoldReason;
 	type FreezeIdentifier = [u8; 8];
 	type MaxFreezes = ConstU32<50>;
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {
@@ -181,6 +182,7 @@ impl pallet_session::Config for Runtime {
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Runtime>;
 	type WeightInfo = ();
+	type DisablingStrategy = pallet_session::disabling::UpToLimitDisablingStrategy;
 }
 
 pub struct OnChainSeqPhragmen;
@@ -224,7 +226,9 @@ impl pallet_staking::Config for Runtime {
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type NominationsQuota = pallet_staking::FixedNominationsQuota<MAX_QUOTA_NOMINATIONS>;
 	type WeightInfo = ();
-	type DisablingStrategy = pallet_staking::UpToLimitDisablingStrategy;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type Filter = frame_support::traits::Everything;
 }
 
 parameter_types! {
@@ -250,6 +254,7 @@ impl pallet_assets::Config for Runtime {
 	type CallbackHandle = ();
 	type Extra = ();
 	type RemoveItemsLimit = ConstU32<5>;
+	type Holder = ();
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
 }
@@ -583,6 +588,7 @@ construct_runtime!(
 	}
 );
 
+#[allow(dead_code)]
 pub struct ExtBuilder;
 
 impl Default for ExtBuilder {

--- a/pallets/multi-asset-delegation/src/migrations.rs
+++ b/pallets/multi-asset-delegation/src/migrations.rs
@@ -282,7 +282,7 @@ impl<T: Config> OnRuntimeUpgrade for DelegatorMetadataMigration<T> {
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::DispatchError> {
 		// Count how many entries we have pre-migration
 		let count = Delegators::<T>::iter().count() as u32;
 		log::info!("DelegatorMetadataMigration pre_upgrade: Found {} delegator entries", count);
@@ -304,12 +304,14 @@ impl<T: Config> OnRuntimeUpgrade for DelegatorMetadataMigration<T> {
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(state: Vec<u8>) -> Result<(), &'static str> {
+	fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+		use sp_runtime::DispatchError;
+
 		// Decode the state from pre_upgrade
 		let mut state_cursor = &state[..];
 
 		let pre_count =
-			u32::decode(&mut state_cursor).map_err(|_| "Failed to decode pre-migration count")?;
+			u32::decode(&mut state_cursor).map_err(|_| DispatchError::Other("Failed to decode pre-migration count"))?;
 
 		// Get the current count
 		let post_count = Delegators::<T>::iter().count() as u32;
@@ -321,28 +323,28 @@ impl<T: Config> OnRuntimeUpgrade for DelegatorMetadataMigration<T> {
 				pre_count,
 				post_count
 			);
-			return Err("Entry count decreased after migration");
+			return Err(DispatchError::Other("Entry count decreased after migration"));
 		}
 
 		// Verify the sampled accounts still exist
 		let sample_count =
-			u32::decode(&mut state_cursor).map_err(|_| "Failed to decode sample count")?;
+			u32::decode(&mut state_cursor).map_err(|_| DispatchError::Other("Failed to decode sample count"))?;
 
 		for _ in 0..sample_count {
 			let account_id = <T as frame_system::Config>::AccountId::decode(&mut state_cursor)
-				.map_err(|_| "Failed to decode account ID")?;
+				.map_err(|_| DispatchError::Other("Failed to decode account ID"))?;
 
 			if !Delegators::<T>::contains_key(&account_id) {
 				log::error!(
 					"DelegatorMetadataMigration post_upgrade: Account {:?} missing after migration",
 					account_id
 				);
-				return Err("Account missing after migration");
+				return Err(DispatchError::Other("Account missing after migration"));
 			}
 
 			// Verify the new structure has the expected fields
 			let metadata =
-				Delegators::<T>::get(&account_id).ok_or("Failed to get metadata for account")?;
+				Delegators::<T>::get(&account_id).ok_or(DispatchError::Other("Failed to get metadata for account"))?;
 
 			// Check that delegations have is_nomination field
 			for delegation in metadata.delegations.iter() {

--- a/pallets/multi-asset-delegation/src/tests/delegate.rs
+++ b/pallets/multi-asset-delegation/src/tests/delegate.rs
@@ -17,15 +17,18 @@
 use super::*;
 use crate::{CurrentRound, Error};
 use frame_support::{assert_noop, assert_ok};
-use sp_keyring::AccountKeyring::{Alice, Bob, Charlie};
 use tangle_primitives::services::Asset;
+
+const ALICE: u8 = 1;
+const BOB: u8 = 2;
+const CHARLIE: u8 = 3;
 
 #[test]
 fn delegate_should_work() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -85,8 +88,8 @@ fn delegate_should_work() {
 fn schedule_delegator_unstake_should_work() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -150,8 +153,8 @@ fn schedule_delegator_unstake_should_work() {
 fn execute_delegator_unstake_should_work() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -206,8 +209,8 @@ fn execute_delegator_unstake_should_work() {
 fn cancel_delegator_unstake_should_work() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -281,8 +284,8 @@ fn cancel_delegator_unstake_should_work() {
 fn cancel_delegator_unstake_should_update_already_existing() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -360,8 +363,8 @@ fn cancel_delegator_unstake_should_update_already_existing() {
 fn delegate_should_fail_if_not_enough_balance() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let asset = Asset::Custom(VDOT);
 		let amount = 10_000;
 
@@ -397,8 +400,8 @@ fn delegate_should_fail_if_not_enough_balance() {
 fn schedule_delegator_unstake_should_fail_if_no_delegation() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -434,8 +437,8 @@ fn schedule_delegator_unstake_should_fail_if_no_delegation() {
 fn execute_delegator_unstake_should_fail_if_not_ready() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -490,8 +493,8 @@ fn execute_delegator_unstake_should_fail_if_not_ready() {
 fn delegate_should_not_create_multiple_on_repeat_delegation() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 		let additional_amount = 50;
@@ -563,7 +566,7 @@ fn delegate_should_not_create_multiple_on_repeat_delegation() {
 #[test]
 fn delegate_exceeds_max_delegations() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let amount = 100;
 
 		// Setup max number of operators
@@ -605,7 +608,7 @@ fn delegate_exceeds_max_delegations() {
 			));
 		}
 
-		let operator: AccountId = Charlie.into();
+		let operator: AccountId = mock_pub_key(CHARLIE);
 		// Give operator enough balance to join
 		assert_ok!(Balances::force_set_balance(RuntimeOrigin::root(), operator.clone(), 100_000));
 		assert_ok!(MultiAssetDelegation::join_operators(
@@ -632,8 +635,8 @@ fn delegate_exceeds_max_delegations() {
 #[test]
 fn delegate_insufficient_deposit() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let deposit_amount = 100;
 		let delegate_amount = deposit_amount + 1;
 		let asset = Asset::Custom(USDC);
@@ -678,8 +681,8 @@ fn delegate_insufficient_deposit() {
 #[test]
 fn delegate_to_inactive_operator() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100;
 
 		// Setup operator but make them inactive
@@ -720,8 +723,8 @@ fn delegate_to_inactive_operator() {
 #[test]
 fn delegate_repeated_same_asset() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let initial_amount = 100;
 		let additional_amount = 50;
 
@@ -780,8 +783,8 @@ fn delegate_repeated_same_asset() {
 #[test]
 fn delegate_multiple_assets_same_operator() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100;
 
 		// Setup operator
@@ -836,8 +839,8 @@ fn delegate_multiple_assets_same_operator() {
 #[test]
 fn delegate_zero_amount() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 
 		// Setup operator
 		assert_ok!(MultiAssetDelegation::join_operators(
@@ -862,8 +865,8 @@ fn delegate_zero_amount() {
 #[test]
 fn delegate_with_no_deposit() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100;
 
 		// Setup operator
@@ -895,8 +898,8 @@ fn debug_tnt_delegation_verify_nomination_issue() {
 	new_test_ext().execute_with(|| {
 		// This test verifies TNT delegation works correctly without nomination verification
 
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 1000;
 		let delegate_amount = 500;
 
@@ -942,8 +945,8 @@ fn delegation_unstake_bug_with_nomination_pending() {
 	// Test case that reproduces the bug where delegation unstake calculation
 	// incorrectly includes nomination unstake requests
 	new_test_ext().execute_with(|| {
-		let delegator: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let delegator: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		// Use the same asset that nominations use: Asset::Custom(Zero::zero()) which is
 		// Asset::Custom(0)
 		let asset = Asset::Custom(0);

--- a/pallets/multi-asset-delegation/src/tests/deposit.rs
+++ b/pallets/multi-asset-delegation/src/tests/deposit.rs
@@ -16,9 +16,10 @@
 use super::*;
 use crate::{CurrentRound, Error};
 use frame_support::{assert_err, assert_noop, assert_ok};
-use sp_keyring::AccountKeyring::Bob;
 use sp_runtime::{ArithmeticError, DispatchError};
 use tangle_primitives::services::{Asset, EvmAddressMapping};
+
+const BOB: u8 = 2;
 
 pub fn create_and_mint_tokens(
 	asset: AssetId,
@@ -42,7 +43,7 @@ pub fn mint_tokens(
 fn deposit_should_work_for_fungible_asset() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let amount = 200;
 
 		create_and_mint_tokens(VDOT, who.clone(), amount);
@@ -79,7 +80,7 @@ fn deposit_should_work_for_fungible_asset() {
 fn deposit_should_work_for_evm_asset() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let amount = 200;
 
 		create_and_mint_tokens(VDOT, who.clone(), amount);
@@ -112,7 +113,7 @@ fn deposit_should_work_for_evm_asset() {
 fn multiple_deposit_should_work() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let amount = 200;
 
 		create_and_mint_tokens(VDOT, who.clone(), amount * 4);
@@ -167,7 +168,7 @@ fn multiple_deposit_should_work() {
 fn deposit_should_fail_for_insufficient_balance() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let amount = 2000;
 
 		create_and_mint_tokens(VDOT, who.clone(), 100);
@@ -189,7 +190,7 @@ fn deposit_should_fail_for_insufficient_balance() {
 fn deposit_should_fail_for_bond_too_low() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let amount = 50; // Below the minimum stake amount
 
 		create_and_mint_tokens(VDOT, who.clone(), amount);
@@ -211,7 +212,7 @@ fn deposit_should_fail_for_bond_too_low() {
 fn schedule_withdraw_should_work() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -249,7 +250,7 @@ fn schedule_withdraw_should_work() {
 fn schedule_withdraw_should_fail_if_not_delegator() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -270,7 +271,7 @@ fn schedule_withdraw_should_fail_if_not_delegator() {
 fn schedule_withdraw_should_fail_for_insufficient_balance() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let asset = Asset::Custom(VDOT);
 		let amount = 200;
 
@@ -300,7 +301,7 @@ fn schedule_withdraw_should_fail_for_insufficient_balance() {
 fn schedule_withdraw_should_fail_if_withdraw_request_exists() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -328,7 +329,7 @@ fn schedule_withdraw_should_fail_if_withdraw_request_exists() {
 fn execute_withdraw_should_work() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -372,7 +373,7 @@ fn execute_withdraw_should_work() {
 fn execute_withdraw_should_fail_if_not_delegator() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 
 		assert_noop!(
 			MultiAssetDelegation::execute_withdraw(RuntimeOrigin::signed(who.clone()), None),
@@ -385,7 +386,7 @@ fn execute_withdraw_should_fail_if_not_delegator() {
 fn execute_withdraw_should_fail_if_no_withdraw_request() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -411,7 +412,7 @@ fn execute_withdraw_should_fail_if_no_withdraw_request() {
 fn execute_withdraw_should_fail_if_withdraw_not_ready() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -509,7 +510,7 @@ fn execute_withdraw_should_fail_if_caller_not_pallet_from_evm() {
 fn cancel_withdraw_should_work() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -553,7 +554,7 @@ fn cancel_withdraw_should_work() {
 fn cancel_withdraw_should_fail_if_not_delegator() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 
 		assert_noop!(
 			MultiAssetDelegation::cancel_withdraw(
@@ -570,7 +571,7 @@ fn cancel_withdraw_should_fail_if_not_delegator() {
 fn cancel_withdraw_should_fail_if_no_withdraw_request() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let asset = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -600,7 +601,7 @@ fn cancel_withdraw_should_fail_if_no_withdraw_request() {
 fn deposit_should_work_for_tnt_without_adding_to_reward_vault() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
+		let who: AccountId = mock_pub_key(BOB);
 		let amount = 200;
 
 		assert_ok!(MultiAssetDelegation::deposit(

--- a/pallets/multi-asset-delegation/src/tests/native_restaking.rs
+++ b/pallets/multi-asset-delegation/src/tests/native_restaking.rs
@@ -23,17 +23,20 @@ use frame_support::{
 	pallet_prelude::{InvalidTransaction, TransactionValidityError},
 	traits::Hooks,
 };
-use sp_keyring::AccountKeyring::{Alice, Bob, Charlie, Dave};
-use sp_runtime::traits::SignedExtension;
+const ALICE: u8 = 1;
+const BOB: u8 = 2;
+const CHARLIE: u8 = 3;
+const DAVE: u8 = 4;
+use sp_runtime::traits::TransactionExtension;
 use tangle_primitives::services::Asset;
 
 #[test]
 fn native_restaking_should_work() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Dave.into();
+		let who: AccountId = mock_pub_key(DAVE);
 		let validator = Staking::invulnerables()[0].clone();
-		let operator: AccountId = Alice.into();
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100_000;
 		let delegate_amount = amount / 2;
 		// Bond Some TNT
@@ -100,9 +103,9 @@ fn native_restaking_should_work() {
 fn unbond_should_fail_if_delegated_nomination() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Dave.into();
+		let who: AccountId = mock_pub_key(DAVE);
 		let validator = Staking::invulnerables()[0].clone();
-		let operator: AccountId = Alice.into();
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100_000;
 		let delegate_amount = amount / 2;
 		// Bond Some TNT
@@ -167,11 +170,14 @@ fn unbond_should_fail_if_delegated_nomination() {
 		// Try to unbond from the staking pallet - should fail
 		assert_err!(
 			CheckNominatedRestaked::<Runtime>::new().validate(
-				&who,
+				RuntimeOrigin::signed(who.clone()),
 				&call,
 				&DispatchInfo::default(),
-				0
-			),
+				0,
+				(),
+				&sp_runtime::traits::TxBaseImplication(()),
+				sp_runtime::transaction_validity::TransactionSource::External,
+			).map(|(_, _, _)| ()),
 			TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
 		);
 
@@ -203,8 +209,8 @@ fn unbond_should_fail_if_delegated_nomination() {
 fn successful_multiple_native_restaking() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let total_nomination = 100;
 		let first_restake = 40;
 		let second_restake = 30;
@@ -258,8 +264,8 @@ fn successful_multiple_native_restaking() {
 #[test]
 fn native_restake_exceeding_nomination_amount() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let nomination_amount = 100;
 		let excessive_amount = 150;
 
@@ -293,8 +299,8 @@ fn native_restake_exceeding_nomination_amount() {
 #[test]
 fn native_restake_with_no_active_nomination() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100;
 
 		// Setup operator
@@ -319,8 +325,8 @@ fn native_restake_with_no_active_nomination() {
 #[test]
 fn native_restake_to_non_operator() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let non_operator: AccountId = Charlie.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let non_operator: AccountId = mock_pub_key(CHARLIE);
 		let amount = 100;
 
 		// Setup nomination
@@ -349,8 +355,8 @@ fn native_restake_to_non_operator() {
 #[test]
 fn native_restake_and_unstake_flow() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100;
 		let unstake_amount = 40;
 
@@ -409,8 +415,8 @@ fn native_restake_and_unstake_flow() {
 #[test]
 fn native_restake_zero_amount() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100;
 
 		// Setup
@@ -441,8 +447,8 @@ fn native_restake_zero_amount() {
 #[test]
 fn native_restake_concurrent_operations() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100;
 
 		// Setup
@@ -488,8 +494,8 @@ fn native_restake_concurrent_operations() {
 #[test]
 fn native_restake_early_unstake_execution_fails() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100;
 		let unstake_amount = 40;
 
@@ -565,8 +571,8 @@ fn native_restake_early_unstake_execution_fails() {
 #[test]
 fn native_restake_cancel_unstake() {
 	new_test_ext().execute_with(|| {
-		let who: AccountId = Bob.into();
-		let operator: AccountId = Alice.into();
+		let who: AccountId = mock_pub_key(BOB);
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100;
 		let unstake_amount = 40;
 
@@ -634,10 +640,10 @@ fn native_restake_cancel_unstake() {
 fn proxy_unbond_should_fail_if_delegated_nomination() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Dave.into();
-		let proxy: AccountId = Charlie.into();
+		let who: AccountId = mock_pub_key(DAVE);
+		let proxy: AccountId = mock_pub_key(CHARLIE);
 		let validator = Staking::invulnerables()[0].clone();
-		let operator: AccountId = Alice.into();
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100_000;
 		let delegate_amount = amount / 2;
 
@@ -688,11 +694,14 @@ fn proxy_unbond_should_fail_if_delegated_nomination() {
 
 		assert_err!(
 			CheckNominatedRestaked::<Runtime>::new().validate(
-				&proxy,
+				RuntimeOrigin::signed(proxy.clone()),
 				&proxy_call,
 				&DispatchInfo::default(),
-				0
-			),
+				0,
+				(),
+				&sp_runtime::traits::TxBaseImplication(()),
+				sp_runtime::transaction_validity::TransactionSource::External,
+			).map(|(_, _, _)| ()),
 			TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
 		);
 
@@ -708,9 +717,9 @@ fn proxy_unbond_should_fail_if_delegated_nomination() {
 fn batch_unbond_should_fail_if_delegated_nomination() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Dave.into();
+		let who: AccountId = mock_pub_key(DAVE);
 		let validator = Staking::invulnerables()[0].clone();
-		let operator: AccountId = Alice.into();
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100_000;
 		let delegate_amount = amount / 2;
 
@@ -749,11 +758,14 @@ fn batch_unbond_should_fail_if_delegated_nomination() {
 
 		assert_err!(
 			CheckNominatedRestaked::<Runtime>::new().validate(
-				&who,
+				RuntimeOrigin::signed(who.clone()),
 				&batch_call,
 				&DispatchInfo::default(),
-				0
-			),
+				0,
+				(),
+				&sp_runtime::traits::TxBaseImplication(()),
+				sp_runtime::transaction_validity::TransactionSource::External,
+			).map(|(_, _, _)| ()),
 			TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
 		);
 
@@ -769,10 +781,10 @@ fn batch_unbond_should_fail_if_delegated_nomination() {
 fn proxy_batch_unbond_should_fail_if_delegated_nomination() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who: AccountId = Dave.into();
-		let proxy: AccountId = Charlie.into();
+		let who: AccountId = mock_pub_key(DAVE);
+		let proxy: AccountId = mock_pub_key(CHARLIE);
 		let validator = Staking::invulnerables()[0].clone();
-		let operator: AccountId = Alice.into();
+		let operator: AccountId = mock_pub_key(ALICE);
 		let amount = 100_000;
 		let delegate_amount = amount / 2;
 
@@ -824,11 +836,14 @@ fn proxy_batch_unbond_should_fail_if_delegated_nomination() {
 
 		assert_err!(
 			CheckNominatedRestaked::<Runtime>::new().validate(
-				&proxy,
+				RuntimeOrigin::signed(proxy.clone()),
 				&proxy_batch_call,
 				&DispatchInfo::default(),
-				0
-			),
+				0,
+				(),
+				&sp_runtime::traits::TxBaseImplication(()),
+				sp_runtime::transaction_validity::TransactionSource::External,
+			).map(|(_, _, _)| ()),
 			TransactionValidityError::Invalid(InvalidTransaction::Custom(1))
 		);
 

--- a/pallets/multi-asset-delegation/src/tests/operator.rs
+++ b/pallets/multi-asset-delegation/src/tests/operator.rs
@@ -19,8 +19,11 @@ use crate::{
 	types::{DelegatorBlueprintSelection::Fixed, OperatorStatus},
 };
 use frame_support::{assert_noop, assert_ok};
-use sp_keyring::AccountKeyring::{Alice, Bob, Eve};
 use sp_runtime::Percent;
+
+const ALICE: u8 = 1;
+const BOB: u8 = 2;
+const EVE: u8 = 5;
 use tangle_primitives::{
 	services::{Asset, UnappliedSlash},
 	traits::SlashManager,
@@ -32,11 +35,11 @@ fn join_operator_success() {
 		let bond_amount = 10_000;
 
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.stake, bond_amount);
 		assert_eq!(operator_info.delegation_count, 0);
 		assert_eq!(operator_info.request, None);
@@ -44,7 +47,7 @@ fn join_operator_success() {
 
 		// Verify event
 		System::assert_has_event(RuntimeEvent::MultiAssetDelegation(Event::OperatorJoined {
-			who: Alice.to_account_id(),
+			who: mock_pub_key(ALICE),
 		}));
 	});
 }
@@ -55,12 +58,12 @@ fn join_operator_already_operator() {
 		let bond_amount = 10_000;
 
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 		assert_noop!(
 			MultiAssetDelegation::join_operators(
-				RuntimeOrigin::signed(Alice.to_account_id()),
+				RuntimeOrigin::signed(mock_pub_key(ALICE)),
 				bond_amount
 			),
 			Error::<Runtime>::AlreadyOperator
@@ -75,7 +78,7 @@ fn join_operator_insufficient_bond() {
 
 		assert_noop!(
 			MultiAssetDelegation::join_operators(
-				RuntimeOrigin::signed(Eve.to_account_id()),
+				RuntimeOrigin::signed(mock_pub_key(EVE)),
 				insufficient_bond
 			),
 			Error::<Runtime>::BondTooLow
@@ -90,7 +93,7 @@ fn join_operator_insufficient_funds() {
 
 		assert_noop!(
 			MultiAssetDelegation::join_operators(
-				RuntimeOrigin::signed(Alice.to_account_id()),
+				RuntimeOrigin::signed(mock_pub_key(ALICE)),
 				bond_amount
 			),
 			pallet_balances::Error::<Runtime, _>::InsufficientBalance
@@ -105,11 +108,11 @@ fn join_operator_minimum_bond() {
 		let exact_bond = minimum_bond;
 
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			exact_bond
 		));
 
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.stake, exact_bond);
 	});
 }
@@ -122,7 +125,7 @@ fn schedule_leave_operator_success() {
 		// Schedule leave operators without joining
 		assert_noop!(
 			MultiAssetDelegation::schedule_leave_operators(RuntimeOrigin::signed(
-				Alice.to_account_id()
+				mock_pub_key(ALICE)
 			)),
 			Error::<Runtime>::NotAnOperator
 		);
@@ -132,22 +135,22 @@ fn schedule_leave_operator_success() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// Schedule leave operators
 		assert_ok!(MultiAssetDelegation::schedule_leave_operators(RuntimeOrigin::signed(
-			Alice.to_account_id()
+			mock_pub_key(ALICE)
 		)));
 
 		// Verify operator metadata
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.status, OperatorStatus::Leaving(15)); // current_round (5) + leave_operators_delay (10)
 
 		// Verify event
 		System::assert_has_event(RuntimeEvent::MultiAssetDelegation(
-			Event::OperatorLeavingScheduled { who: Alice.to_account_id() },
+			Event::OperatorLeavingScheduled { who: mock_pub_key(ALICE) },
 		));
 	});
 }
@@ -159,7 +162,7 @@ fn cancel_leave_operator_tests() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
@@ -168,44 +171,44 @@ fn cancel_leave_operator_tests() {
 
 		// Schedule leave operators
 		assert_ok!(MultiAssetDelegation::schedule_leave_operators(RuntimeOrigin::signed(
-			Alice.to_account_id()
+			mock_pub_key(ALICE)
 		)));
 
 		// Verify operator metadata after cancellation
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.status, OperatorStatus::Leaving(15)); // current_round (5) + leave_operators_delay (10)
 
 		// Test: Cancel leave operators successfully
 		assert_ok!(MultiAssetDelegation::cancel_leave_operators(RuntimeOrigin::signed(
-			Alice.to_account_id()
+			mock_pub_key(ALICE)
 		)));
 
 		// Verify operator metadata after cancellation
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.status, OperatorStatus::Active); // current_round (5) + leave_operators_delay (10)
 
 		// Verify event for cancellation
 		System::assert_has_event(RuntimeEvent::MultiAssetDelegation(
-			Event::OperatorLeaveCancelled { who: Alice.to_account_id() },
+			Event::OperatorLeaveCancelled { who: mock_pub_key(ALICE) },
 		));
 
 		// Test: Cancel leave operators without being in leaving state
 		assert_noop!(
 			MultiAssetDelegation::cancel_leave_operators(RuntimeOrigin::signed(
-				Alice.to_account_id()
+				mock_pub_key(ALICE)
 			)),
 			Error::<Runtime>::NotLeavingOperator
 		);
 
 		// Test: Schedule leave operators again
 		assert_ok!(MultiAssetDelegation::schedule_leave_operators(RuntimeOrigin::signed(
-			Alice.to_account_id()
+			mock_pub_key(ALICE)
 		)));
 
 		// Test: Cancel leave operators without being an operator
 		assert_noop!(
 			MultiAssetDelegation::cancel_leave_operators(RuntimeOrigin::signed(
-				Bob.to_account_id()
+				mock_pub_key(BOB)
 			)),
 			Error::<Runtime>::NotAnOperator
 		);
@@ -220,23 +223,23 @@ fn operator_bond_more_success() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// stake more TNT
 		assert_ok!(MultiAssetDelegation::operator_bond_more(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			additional_bond
 		));
 
 		// Verify operator metadata
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.stake, bond_amount + additional_bond);
 
 		// Verify event
 		System::assert_has_event(RuntimeEvent::MultiAssetDelegation(Event::OperatorBondMore {
-			who: Alice.to_account_id(),
+			who: mock_pub_key(ALICE),
 			additional_bond,
 		}));
 	});
@@ -250,7 +253,7 @@ fn operator_bond_more_not_an_operator() {
 		// Attempt to stake more without being an operator
 		assert_noop!(
 			MultiAssetDelegation::operator_bond_more(
-				RuntimeOrigin::signed(Alice.to_account_id()),
+				RuntimeOrigin::signed(mock_pub_key(ALICE)),
 				additional_bond
 			),
 			Error::<Runtime>::NotAnOperator
@@ -266,14 +269,14 @@ fn operator_bond_more_insufficient_balance() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// Attempt to stake more with insufficient balance
 		assert_noop!(
 			MultiAssetDelegation::operator_bond_more(
-				RuntimeOrigin::signed(Alice.to_account_id()),
+				RuntimeOrigin::signed(mock_pub_key(ALICE)),
 				additional_bond
 			),
 			pallet_balances::Error::<Runtime>::InsufficientBalance
@@ -289,18 +292,18 @@ fn schedule_operator_unstake_success() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// Schedule unstake
 		assert_ok!(MultiAssetDelegation::schedule_operator_unstake(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			unstake_amount
 		));
 
 		// Verify operator metadata
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.request.unwrap().amount, unstake_amount);
 
 		// Verify remaining stake is above minimum
@@ -311,7 +314,7 @@ fn schedule_operator_unstake_success() {
 
 		// Verify event
 		System::assert_has_event(RuntimeEvent::MultiAssetDelegation(
-			Event::OperatorBondLessScheduled { who: Alice.to_account_id(), unstake_amount },
+			Event::OperatorBondLessScheduled { who: mock_pub_key(ALICE), unstake_amount },
 		));
 	});
 }
@@ -325,14 +328,14 @@ fn schedule_operator_unstake_respects_minimum_stake() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// Attempt to schedule unstake that would leave less than minimum
 		assert_noop!(
 			MultiAssetDelegation::schedule_operator_unstake(
-				RuntimeOrigin::signed(Alice.to_account_id()),
+				RuntimeOrigin::signed(mock_pub_key(ALICE)),
 				unstake_amount
 			),
 			Error::<Runtime>::InsufficientStakeRemaining
@@ -348,7 +351,7 @@ fn schedule_operator_unstake_not_an_operator() {
 		// Attempt to schedule unstake without being an operator
 		assert_noop!(
 			MultiAssetDelegation::schedule_operator_unstake(
-				RuntimeOrigin::signed(Alice.to_account_id()),
+				RuntimeOrigin::signed(mock_pub_key(ALICE)),
 				unstake_amount
 			),
 			Error::<Runtime>::NotAnOperator
@@ -377,7 +380,7 @@ fn schedule_operator_unstake_not_an_operator() {
 //         // Attempt to schedule unstake with active services
 //         assert_noop!(
 //
-// MultiAssetDelegation::schedule_operator_unstake(RuntimeOrigin::signed(Alice.to_account_id()),
+// MultiAssetDelegation::schedule_operator_unstake(RuntimeOrigin::signed(mock_pub_key(ALICE)),
 // unstake_amount),             Error::<Runtime>::ActiveServicesUsingTNT
 //         );
 //     });
@@ -391,35 +394,35 @@ fn execute_operator_unstake_success() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// Schedule unstake
 		assert_ok!(MultiAssetDelegation::schedule_operator_unstake(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			unstake_amount
 		));
 
 		// Set the current round to simulate passage of time
 		<CurrentRound<Runtime>>::put(15);
 
-		let reserved_balance = Balances::reserved_balance(Alice.to_account_id());
+		let reserved_balance = Balances::reserved_balance(mock_pub_key(ALICE));
 		// Execute unstake
 		assert_ok!(MultiAssetDelegation::execute_operator_unstake(RuntimeOrigin::signed(
-			Alice.to_account_id()
+			mock_pub_key(ALICE)
 		)));
 
-		let reserved_balance_after = Balances::reserved_balance(Alice.to_account_id());
+		let reserved_balance_after = Balances::reserved_balance(mock_pub_key(ALICE));
 		// Verify operator metadata
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.stake, bond_amount - unstake_amount);
 		assert_eq!(operator_info.request, None);
 		assert_eq!(reserved_balance - reserved_balance_after, unstake_amount);
 
 		// Verify event
 		System::assert_has_event(RuntimeEvent::MultiAssetDelegation(
-			Event::OperatorBondLessExecuted { who: Alice.to_account_id() },
+			Event::OperatorBondLessExecuted { who: mock_pub_key(ALICE) },
 		));
 	});
 }
@@ -430,7 +433,7 @@ fn execute_operator_unstake_not_an_operator() {
 		// Attempt to execute unstake without being an operator
 		assert_noop!(
 			MultiAssetDelegation::execute_operator_unstake(RuntimeOrigin::signed(
-				Alice.to_account_id()
+				mock_pub_key(ALICE)
 			)),
 			Error::<Runtime>::NotAnOperator
 		);
@@ -444,14 +447,14 @@ fn execute_operator_unstake_no_scheduled_unstake() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// Attempt to execute unstake without scheduling it
 		assert_noop!(
 			MultiAssetDelegation::execute_operator_unstake(RuntimeOrigin::signed(
-				Alice.to_account_id()
+				mock_pub_key(ALICE)
 			)),
 			Error::<Runtime>::NoScheduledBondLess
 		);
@@ -466,20 +469,20 @@ fn execute_operator_unstake_request_not_satisfied() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// Schedule unstake
 		assert_ok!(MultiAssetDelegation::schedule_operator_unstake(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			unstake_amount
 		));
 
 		// Attempt to execute unstake before request is satisfied
 		assert_noop!(
 			MultiAssetDelegation::execute_operator_unstake(RuntimeOrigin::signed(
-				Alice.to_account_id()
+				mock_pub_key(ALICE)
 			)),
 			Error::<Runtime>::BondLessRequestNotSatisfied
 		);
@@ -494,28 +497,28 @@ fn cancel_operator_unstake_success() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// Schedule unstake
 		assert_ok!(MultiAssetDelegation::schedule_operator_unstake(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			unstake_amount
 		));
 
 		// Cancel unstake
 		assert_ok!(MultiAssetDelegation::cancel_operator_unstake(RuntimeOrigin::signed(
-			Alice.to_account_id()
+			mock_pub_key(ALICE)
 		)));
 
 		// Verify operator metadata
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.request, None);
 
 		// Verify event
 		System::assert_has_event(RuntimeEvent::MultiAssetDelegation(
-			Event::OperatorBondLessCancelled { who: Alice.to_account_id() },
+			Event::OperatorBondLessCancelled { who: mock_pub_key(ALICE) },
 		));
 	});
 }
@@ -526,7 +529,7 @@ fn cancel_operator_unstake_not_an_operator() {
 		// Attempt to cancel unstake without being an operator
 		assert_noop!(
 			MultiAssetDelegation::cancel_operator_unstake(RuntimeOrigin::signed(
-				Alice.to_account_id()
+				mock_pub_key(ALICE)
 			)),
 			Error::<Runtime>::NotAnOperator
 		);
@@ -540,14 +543,14 @@ fn cancel_operator_unstake_no_scheduled_unstake() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// Attempt to cancel unstake without scheduling it
 		assert_noop!(
 			MultiAssetDelegation::cancel_operator_unstake(RuntimeOrigin::signed(
-				Alice.to_account_id()
+				mock_pub_key(ALICE)
 			)),
 			Error::<Runtime>::NoScheduledBondLess
 		);
@@ -561,20 +564,20 @@ fn go_offline_success() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// Go offline
-		assert_ok!(MultiAssetDelegation::go_offline(RuntimeOrigin::signed(Alice.to_account_id())));
+		assert_ok!(MultiAssetDelegation::go_offline(RuntimeOrigin::signed(mock_pub_key(ALICE))));
 
 		// Verify operator metadata
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.status, OperatorStatus::Inactive);
 
 		// Verify event
 		System::assert_has_event(RuntimeEvent::MultiAssetDelegation(Event::OperatorWentOffline {
-			who: Alice.to_account_id(),
+			who: mock_pub_key(ALICE),
 		}));
 	});
 }
@@ -584,7 +587,7 @@ fn go_offline_not_an_operator() {
 	new_test_ext().execute_with(|| {
 		// Attempt to go offline without being an operator
 		assert_noop!(
-			MultiAssetDelegation::go_offline(RuntimeOrigin::signed(Alice.to_account_id())),
+			MultiAssetDelegation::go_offline(RuntimeOrigin::signed(mock_pub_key(ALICE))),
 			Error::<Runtime>::NotAnOperator
 		);
 	});
@@ -597,23 +600,23 @@ fn go_online_success() {
 
 		// Join operator first
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			bond_amount
 		));
 
 		// Go offline first
-		assert_ok!(MultiAssetDelegation::go_offline(RuntimeOrigin::signed(Alice.to_account_id())));
+		assert_ok!(MultiAssetDelegation::go_offline(RuntimeOrigin::signed(mock_pub_key(ALICE))));
 
 		// Go online
-		assert_ok!(MultiAssetDelegation::go_online(RuntimeOrigin::signed(Alice.to_account_id())));
+		assert_ok!(MultiAssetDelegation::go_online(RuntimeOrigin::signed(mock_pub_key(ALICE))));
 
 		// Verify operator metadata
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.status, OperatorStatus::Active);
 
 		// Verify event
 		System::assert_has_event(RuntimeEvent::MultiAssetDelegation(Event::OperatorWentOnline {
-			who: Alice.to_account_id(),
+			who: mock_pub_key(ALICE),
 		}));
 	});
 }
@@ -624,7 +627,7 @@ fn slash_operator_success() {
 		// Setup operator
 		let operator_stake = 10_000;
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			operator_stake
 		));
 
@@ -637,11 +640,11 @@ fn slash_operator_success() {
 		let service_id = 42;
 
 		// Setup first delegator with asset1 and selected blueprint
-		create_and_mint_tokens(1, Bob.to_account_id(), delegator1_stake);
-		mint_tokens(Bob.to_account_id(), 1, Bob.to_account_id(), delegator1_stake);
+		create_and_mint_tokens(1, mock_pub_key(BOB), delegator1_stake);
+		mint_tokens(mock_pub_key(BOB), 1, mock_pub_key(BOB), delegator1_stake);
 
 		assert_ok!(MultiAssetDelegation::deposit(
-			RuntimeOrigin::signed(Bob.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(BOB)),
 			asset1,
 			delegator1_stake,
 			None,
@@ -649,24 +652,24 @@ fn slash_operator_success() {
 		));
 
 		assert_ok!(MultiAssetDelegation::add_blueprint_id(
-			RuntimeOrigin::signed(Bob.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(BOB)),
 			blueprint_id
 		));
 
 		assert_ok!(MultiAssetDelegation::delegate(
-			RuntimeOrigin::signed(Bob.to_account_id()),
-			Alice.to_account_id(),
+			RuntimeOrigin::signed(mock_pub_key(BOB)),
+			mock_pub_key(ALICE),
 			asset1,
 			delegator1_stake,
 			Fixed(vec![blueprint_id].try_into().unwrap()),
 		));
 
 		// Setup second delegator with asset2 but without selecting the blueprint
-		create_and_mint_tokens(2, Eve.to_account_id(), delegator2_stake);
-		mint_tokens(Eve.to_account_id(), 2, Eve.to_account_id(), delegator2_stake);
+		create_and_mint_tokens(2, mock_pub_key(EVE), delegator2_stake);
+		mint_tokens(mock_pub_key(EVE), 2, mock_pub_key(EVE), delegator2_stake);
 
 		assert_ok!(MultiAssetDelegation::deposit(
-			RuntimeOrigin::signed(Eve.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(EVE)),
 			asset2,
 			delegator2_stake,
 			None,
@@ -674,8 +677,8 @@ fn slash_operator_success() {
 		));
 
 		assert_ok!(MultiAssetDelegation::delegate(
-			RuntimeOrigin::signed(Eve.to_account_id()),
-			Alice.to_account_id(),
+			RuntimeOrigin::signed(mock_pub_key(EVE)),
+			mock_pub_key(ALICE),
 			asset2,
 			delegator2_stake,
 			Fixed(vec![].try_into().unwrap()),
@@ -689,7 +692,7 @@ fn slash_operator_success() {
 			era: 1,
 			blueprint_id,
 			service_id,
-			operator: Alice.to_account_id(),
+			operator: mock_pub_key(ALICE),
 			slash_percent: Percent::from_percent(50),
 		};
 
@@ -697,30 +700,30 @@ fn slash_operator_success() {
 		assert_ok!(MultiAssetDelegation::slash_operator(&unapplied_slash));
 
 		// Verify operator stake was slashed
-		let operator_info = MultiAssetDelegation::operator_info(Alice.to_account_id()).unwrap();
+		let operator_info = MultiAssetDelegation::operator_info(mock_pub_key(ALICE)).unwrap();
 		assert_eq!(operator_info.stake, operator_stake - exposed_stake);
 
 		// Verify first delegator (Bob) was slashed
-		let delegator1 = MultiAssetDelegation::delegators(Bob.to_account_id()).unwrap();
+		let delegator1 = MultiAssetDelegation::delegators(mock_pub_key(BOB)).unwrap();
 		let delegation1 = delegator1
 			.delegations
 			.iter()
-			.find(|d| d.operator == Alice.to_account_id() && d.asset == asset1)
+			.find(|d| d.operator == mock_pub_key(ALICE) && d.asset == asset1)
 			.unwrap();
 		assert_eq!(delegation1.amount, delegator1_stake - exposed_delegation);
 
 		// Verify second delegator (Eve) was NOT slashed since they didn't select the blueprint
-		let delegator2 = MultiAssetDelegation::delegators(Eve.to_account_id()).unwrap();
+		let delegator2 = MultiAssetDelegation::delegators(mock_pub_key(EVE)).unwrap();
 		let delegation2 = delegator2
 			.delegations
 			.iter()
-			.find(|d| d.operator == Alice.to_account_id() && d.asset == asset2)
+			.find(|d| d.operator == mock_pub_key(ALICE) && d.asset == asset2)
 			.unwrap();
 		assert_eq!(delegation2.amount, delegator2_stake); // Amount unchanged
 
 		// Verify events
 		System::assert_has_event(RuntimeEvent::MultiAssetDelegation(Event::OperatorSlashed {
-			operator: Alice.to_account_id(),
+			operator: mock_pub_key(ALICE),
 			service_id,
 			blueprint_id,
 			era: 1,
@@ -728,7 +731,7 @@ fn slash_operator_success() {
 		}));
 
 		System::assert_has_event(RuntimeEvent::MultiAssetDelegation(Event::DelegatorSlashed {
-			delegator: Bob.to_account_id(),
+			delegator: mock_pub_key(BOB),
 			service_id,
 			blueprint_id,
 			era: 1,
@@ -745,7 +748,7 @@ fn slash_operator_not_an_operator() {
 			era: 1,
 			blueprint_id: 1,
 			service_id: 42,
-			operator: Alice.to_account_id(),
+			operator: mock_pub_key(ALICE),
 			slash_percent: Percent::from_percent(50),
 		};
 
@@ -761,16 +764,16 @@ fn slash_operator_not_active() {
 	new_test_ext().execute_with(|| {
 		// Setup and deactivate operator
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			10_000
 		));
-		assert_ok!(MultiAssetDelegation::go_offline(RuntimeOrigin::signed(Alice.to_account_id())));
+		assert_ok!(MultiAssetDelegation::go_offline(RuntimeOrigin::signed(mock_pub_key(ALICE))));
 
 		let unapplied_slash = UnappliedSlash {
 			era: 1,
 			blueprint_id: 1,
 			service_id: 42,
-			operator: Alice.to_account_id(),
+			operator: mock_pub_key(ALICE),
 			slash_percent: Percent::from_percent(50),
 		};
 
@@ -786,17 +789,17 @@ fn slash_delegator_fixed_blueprint_not_selected() {
 	new_test_ext().execute_with(|| {
 		// Setup operator
 		assert_ok!(MultiAssetDelegation::join_operators(
-			RuntimeOrigin::signed(Alice.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(ALICE)),
 			10_000
 		));
 
 		// Setup delegator with fixed blueprint selection
 		let delegator_stake = 5_000;
 		let asset = Asset::Custom(1);
-		create_and_mint_tokens(1, Bob.to_account_id(), delegator_stake);
+		create_and_mint_tokens(1, mock_pub_key(BOB), delegator_stake);
 
 		assert_ok!(MultiAssetDelegation::deposit(
-			RuntimeOrigin::signed(Bob.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(BOB)),
 			asset,
 			delegator_stake,
 			None,
@@ -804,13 +807,13 @@ fn slash_delegator_fixed_blueprint_not_selected() {
 		));
 
 		assert_ok!(MultiAssetDelegation::add_blueprint_id(
-			RuntimeOrigin::signed(Bob.to_account_id()),
+			RuntimeOrigin::signed(mock_pub_key(BOB)),
 			1
 		));
 
 		assert_ok!(MultiAssetDelegation::delegate(
-			RuntimeOrigin::signed(Bob.to_account_id()),
-			Alice.to_account_id(),
+			RuntimeOrigin::signed(mock_pub_key(BOB)),
+			mock_pub_key(ALICE),
 			asset,
 			delegator_stake,
 			Fixed(vec![2].try_into().unwrap()), // Selected blueprint 2, not 1
@@ -821,17 +824,17 @@ fn slash_delegator_fixed_blueprint_not_selected() {
 			era: 1,
 			blueprint_id: 1,
 			service_id: 42,
-			operator: Alice.to_account_id(),
+			operator: mock_pub_key(ALICE),
 			slash_percent: Percent::from_percent(50),
 		};
 
 		// Verify delegator is not slashed since they didn't select blueprint 1
 		assert_ok!(MultiAssetDelegation::slash_operator(&unapplied_slash));
-		let delegator = MultiAssetDelegation::delegators(Bob.to_account_id()).unwrap();
+		let delegator = MultiAssetDelegation::delegators(mock_pub_key(BOB)).unwrap();
 		let delegation = delegator
 			.delegations
 			.iter()
-			.find(|d| d.operator == Alice.to_account_id())
+			.find(|d| d.operator == mock_pub_key(ALICE))
 			.unwrap();
 		assert_eq!(delegation.amount, delegator_stake); // Amount unchanged
 	});

--- a/pallets/multi-asset-delegation/src/tests/session_manager.rs
+++ b/pallets/multi-asset-delegation/src/tests/session_manager.rs
@@ -16,15 +16,18 @@
 use super::*;
 use crate::CurrentRound;
 use frame_support::{assert_noop, assert_ok, traits::OnInitialize};
-use sp_keyring::AccountKeyring::{Alice, Bob, Charlie, Dave};
+const ALICE: u8 = 1;
+const BOB: u8 = 2;
+const CHARLIE: u8 = 3;
+const DAVE: u8 = 4;
 use tangle_primitives::services::Asset;
 
 #[test]
 fn handle_round_change_should_work() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let who = Bob.to_account_id();
-		let operator = Alice.to_account_id();
+		let who = mock_pub_key(BOB);
+		let operator = mock_pub_key(ALICE);
 		let asset_id = Asset::Custom(VDOT);
 		let amount = 100;
 
@@ -72,10 +75,10 @@ fn handle_round_change_should_work() {
 fn handle_round_change_with_unstake_should_work() {
 	new_test_ext().execute_with(|| {
 		// Arrange
-		let delegator1 = Alice.to_account_id();
-		let delegator2 = Bob.to_account_id();
-		let operator1 = Charlie.to_account_id();
-		let operator2 = Dave.to_account_id();
+		let delegator1 = mock_pub_key(ALICE);
+		let delegator2 = mock_pub_key(BOB);
+		let operator1 = mock_pub_key(CHARLIE);
+		let operator2 = mock_pub_key(DAVE);
 		let asset = Asset::Custom(VDOT);
 		let amount1 = 100_000;
 		let amount2 = 100_000;

--- a/pallets/rewards/src/migrations.rs
+++ b/pallets/rewards/src/migrations.rs
@@ -73,28 +73,31 @@ impl<T: Config> OnRuntimeUpgrade for PercentageToPerbillMigration<T> {
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::DispatchError> {
 		// Count how many entries we have pre-migration
 		let count = RewardConfigStorage::<T>::iter().count() as u32;
 		Ok(count.encode())
 	}
 
 	#[cfg(feature = "try-runtime")]
-	fn post_upgrade(state: Vec<u8>) -> Result<(), &'static str> {
+	fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::DispatchError> {
+		use sp_runtime::DispatchError;
+
 		// Ensure we have the same number of entries post-migration
 		let pre_count =
-			u32::decode(&mut &state[..]).expect("pre_upgrade should have encoded a u32");
+			u32::decode(&mut &state[..]).map_err(|_| DispatchError::Other("Failed to decode pre-migration count"))?;
 		let post_count = RewardConfigStorage::<T>::iter().count() as u32;
 
-		assert_eq!(
-			pre_count, post_count,
-			"Number of reward configurations changed during migration"
-		);
+		if pre_count != post_count {
+			return Err(DispatchError::Other("Number of reward configurations changed during migration"));
+		}
 
 		// Validate all APY values are now proper Perbill values
 		for (_vault_id, config) in RewardConfigStorage::<T>::iter() {
 			// Ensure APY is within Perbill range (0..=1_000_000_000)
-			assert!(config.apy.deconstruct() <= 1_000_000_000, "APY value exceeds Perbill maximum");
+			if config.apy.deconstruct() > 1_000_000_000 {
+				return Err(DispatchError::Other("APY value exceeds Perbill maximum"));
+			}
 		}
 
 		log::info!(

--- a/pallets/rewards/src/mock.rs
+++ b/pallets/rewards/src/mock.rs
@@ -15,7 +15,6 @@
 // along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
 #![allow(clippy::all)]
 use crate::{self as pallet_rewards};
-use ethabi::Uint;
 use frame_election_provider_support::{
 	SequentialPhragmen,
 	bounds::{ElectionBounds, ElectionBoundsBuilder},
@@ -29,7 +28,6 @@ use pallet_session::historical as pallet_session_historical;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_core::{H160, sr25519};
-use sp_keyring::AccountKeyring;
 use sp_keystore::{KeystoreExt, KeystorePtr, testing::MemoryKeystore};
 use sp_runtime::{
 	AccountId32, BuildStorage, Perbill,
@@ -41,7 +39,6 @@ use tangle_primitives::{
 	types::rewards::{AssetType, UserDepositWithLocks},
 };
 
-use core::ops::Mul;
 use std::{cell::RefCell, collections::BTreeMap, sync::Arc};
 
 pub type AccountId = AccountId32;
@@ -94,6 +91,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {
@@ -168,6 +166,7 @@ impl pallet_session::Config for Runtime {
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Runtime>;
 	type WeightInfo = ();
+	type DisablingStrategy = pallet_session::disabling::UpToLimitDisablingStrategy;
 }
 
 pub struct OnChainSeqPhragmen;
@@ -211,7 +210,9 @@ impl pallet_staking::Config for Runtime {
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type NominationsQuota = pallet_staking::FixedNominationsQuota<MAX_QUOTA_NOMINATIONS>;
 	type WeightInfo = ();
-	type DisablingStrategy = pallet_staking::UpToLimitDisablingStrategy;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type Filter = ();
 }
 
 parameter_types! {
@@ -238,6 +239,7 @@ impl pallet_assets::Config for Runtime {
 	type CallbackHandle = ();
 	type Extra = ();
 	type RemoveItemsLimit = ConstU32<5>;
+	type Holder = ();
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
 }
@@ -378,6 +380,7 @@ construct_runtime!(
 	}
 );
 
+#[allow(dead_code)]
 pub struct ExtBuilder;
 
 impl Default for ExtBuilder {
@@ -408,18 +411,18 @@ pub fn new_test_ext_raw_authorities() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
 	// We use default for brevity, but you can configure as desired if needed.
 	let authorities: Vec<AccountId> = vec![
-		AccountKeyring::Alice.into(),
-		AccountKeyring::Bob.into(),
-		AccountKeyring::Charlie.into(),
+		mock_pub_key(1),
+		mock_pub_key(2),
+		mock_pub_key(3),
 	];
 	let mut balances: Vec<_> = authorities.iter().map(|i| (i.clone(), 200_000_u128)).collect();
 
 	// Add test accounts with enough balance
-	let test_accounts = vec![AccountKeyring::Dave.into(), AccountKeyring::Eve.into()];
+	let test_accounts = vec![mock_pub_key(4), mock_pub_key(5)];
 
 	balances.extend(test_accounts.iter().map(|i: &AccountId| (i.clone(), 1_000_000_u128)));
 
-	pallet_balances::GenesisConfig::<Runtime> { balances }
+	pallet_balances::GenesisConfig::<Runtime> { balances, dev_accounts: None }
 		.assimilate_storage(&mut t)
 		.unwrap();
 
@@ -430,7 +433,7 @@ pub fn new_test_ext_raw_authorities() -> sp_io::TestExternalities {
 			code: vec![],
 			storage: Default::default(),
 			nonce: Default::default(),
-			balance: Uint::from(1_000).mul(Uint::from(10).pow(Uint::from(18))),
+			balance: sp_core::U256::from(1_000u128) * sp_core::U256::from(10u128).pow(sp_core::U256::from(18)),
 		});
 	}
 
@@ -439,7 +442,7 @@ pub fn new_test_ext_raw_authorities() -> sp_io::TestExternalities {
 			code: vec![],
 			storage: Default::default(),
 			nonce: Default::default(),
-			balance: Uint::from(1_000).mul(Uint::from(10).pow(Uint::from(18))),
+			balance: sp_core::U256::from(1_000u128) * sp_core::U256::from(10u128).pow(sp_core::U256::from(18)),
 		});
 	}
 

--- a/pallets/rewards/src/mock.rs
+++ b/pallets/rewards/src/mock.rs
@@ -380,15 +380,6 @@ construct_runtime!(
 	}
 );
 
-#[allow(dead_code)]
-pub struct ExtBuilder;
-
-impl Default for ExtBuilder {
-	fn default() -> Self {
-		ExtBuilder
-	}
-}
-
 pub fn mock_pub_key(id: u8) -> AccountId {
 	sr25519::Public::from_raw([id; 32]).into()
 }

--- a/pallets/rewards/src/mock_evm.rs
+++ b/pallets/rewards/src/mock_evm.rs
@@ -19,7 +19,7 @@ use crate::mock::{
 };
 use fp_evm::FeeCalculator;
 use frame_support::{PalletId, parameter_types, traits::FindAuthor, weights::Weight};
-use pallet_ethereum::{EthereumBlockHashMapping, IntermediateStateRoot, PostLogContent, RawOrigin};
+use pallet_ethereum::{EthereumBlockHashMapping, PostLogContent, RawOrigin};
 use pallet_evm::{
 	EnsureAddressNever, EnsureAddressRoot, HashedAddressMapping, OnChargeEVMTransaction,
 };
@@ -106,10 +106,7 @@ parameter_types! {
 	pub const WeightPerGas: Weight = Weight::from_parts(20_000, 0);
 }
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
-
+#[allow(dead_code)]
 pub struct FreeEVMExecution;
 
 impl OnChargeEVMTransaction<Runtime> for FreeEVMExecution {
@@ -151,20 +148,30 @@ impl pallet_evm::Config for Runtime {
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type OnChargeTransaction = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type FindAuthor = FindAuthorTruncated;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = ();
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
 	pub const PostBlockAndTxnHashes: PostLogContent = PostLogContent::BlockAndTxnHashes;
 }
 
+pub struct MockStateRoot;
+impl sp_core::Get<H256> for MockStateRoot {
+	fn get() -> H256 {
+		H256::default()
+	}
+}
+
 impl pallet_ethereum::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type StateRoot = IntermediateStateRoot<Self>;
+	type StateRoot = MockStateRoot;
 	type PostLogContent = PostBlockAndTxnHashes;
 	type ExtraDataLength = ConstU32<30>;
 }
@@ -223,6 +230,7 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
 	}
 }
 
+#[allow(dead_code)]
 pub struct MockedEvmRunner;
 
 impl tangle_primitives::services::EvmRunner<Runtime> for MockedEvmRunner {
@@ -241,6 +249,7 @@ impl tangle_primitives::services::EvmRunner<Runtime> for MockedEvmRunner {
 		let max_priority_fee_per_gas = max_fee_per_gas.saturating_mul(U256::from(2));
 		let nonce = None;
 		let access_list = Default::default();
+		let authorization_list = vec![];
 		let weight_limit = None;
 		let proof_size_base_cost = None;
 		<<Runtime as pallet_evm::Config>::Runner as pallet_evm::Runner<Runtime>>::call(
@@ -253,6 +262,7 @@ impl tangle_primitives::services::EvmRunner<Runtime> for MockedEvmRunner {
 			Some(max_priority_fee_per_gas),
 			nonce,
 			access_list,
+			authorization_list,
 			is_transactional,
 			validate,
 			weight_limit,

--- a/pallets/rewards/src/mock_evm.rs
+++ b/pallets/rewards/src/mock_evm.rs
@@ -229,49 +229,6 @@ impl fp_self_contained::SelfContainedCall for RuntimeCall {
 	}
 }
 
-#[allow(dead_code)]
-pub struct MockedEvmRunner;
-
-impl tangle_primitives::services::EvmRunner<Runtime> for MockedEvmRunner {
-	type Error = pallet_evm::Error<Runtime>;
-
-	fn call(
-		source: sp_core::H160,
-		target: sp_core::H160,
-		input: Vec<u8>,
-		value: sp_core::U256,
-		gas_limit: u64,
-		is_transactional: bool,
-		validate: bool,
-	) -> Result<fp_evm::CallInfo, tangle_primitives::services::RunnerError<Self::Error>> {
-		let max_fee_per_gas = FixedGasPrice::min_gas_price().0;
-		let max_priority_fee_per_gas = max_fee_per_gas.saturating_mul(U256::from(2));
-		let nonce = None;
-		let access_list = Default::default();
-		let authorization_list = vec![];
-		let weight_limit = None;
-		let proof_size_base_cost = None;
-		<<Runtime as pallet_evm::Config>::Runner as pallet_evm::Runner<Runtime>>::call(
-			source,
-			target,
-			input,
-			value,
-			gas_limit,
-			Some(max_fee_per_gas),
-			Some(max_priority_fee_per_gas),
-			nonce,
-			access_list,
-			authorization_list,
-			is_transactional,
-			validate,
-			weight_limit,
-			proof_size_base_cost,
-			<Runtime as pallet_evm::Config>::config(),
-		)
-		.map_err(|o| tangle_primitives::services::RunnerError { error: o.error, weight: o.weight })
-	}
-}
-
 pub struct AccountInfo {
 	pub address: H160,
 }

--- a/pallets/rewards/src/mock_evm.rs
+++ b/pallets/rewards/src/mock_evm.rs
@@ -106,7 +106,6 @@ parameter_types! {
 	pub const WeightPerGas: Weight = Weight::from_parts(20_000, 0);
 }
 
-#[allow(dead_code)]
 pub struct FreeEVMExecution;
 
 impl OnChargeEVMTransaction<Runtime> for FreeEVMExecution {
@@ -146,7 +145,7 @@ impl pallet_evm::Config for Runtime {
 	type ChainId = ChainId;
 	type BlockGasLimit = BlockGasLimit;
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
-	type OnChargeTransaction = ();
+	type OnChargeTransaction = FreeEVMExecution;
 	type OnCreate = ();
 	type FindAuthor = FindAuthorTruncated;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;

--- a/pallets/rewards/src/tests/claim.rs
+++ b/pallets/rewards/src/tests/claim.rs
@@ -156,11 +156,7 @@ fn test_claim_rewards_only_unlocked() {
 
 		// Verify approximate expected rewards (19 tokens with some precision loss)
 		let expected_reward = 191 * EIGHTEEN_DECIMALS / 10;
-		let diff = if balance > expected_reward {
-			balance - expected_reward
-		} else {
-			expected_reward - balance
-		};
+		let diff = balance.abs_diff(expected_reward);
 		println!("diff: {:?} {:?}", diff, diff / EIGHTEEN_DECIMALS);
 		assert!(diff <= 2 * EIGHTEEN_DECIMALS);
 	});
@@ -218,11 +214,7 @@ fn test_claim_rewards_with_expired_lock() {
 		// reward for expired locked 10k = 0.01902587519 * 100 = 1.92587519
 		let expected_reward =
 			19 * EIGHTEEN_DECIMALS + 34 * EIGHTEEN_DECIMALS + 2 * EIGHTEEN_DECIMALS;
-		let diff = if balance > expected_reward {
-			balance - expected_reward
-		} else {
-			expected_reward - balance
-		};
+		let diff = balance.abs_diff(expected_reward);
 		assert!(diff < EIGHTEEN_DECIMALS);
 	});
 }
@@ -286,11 +278,7 @@ fn test_claim_rewards_with_active_locks() {
 		// reward for locked 90k = 0.171232876712328767122 * 1000 = 171.232876712328767122
 		let expected_reward =
 			19 * EIGHTEEN_DECIMALS + 76 * EIGHTEEN_DECIMALS + 171 * EIGHTEEN_DECIMALS;
-		let diff = if balance > expected_reward {
-			balance - expected_reward
-		} else {
-			expected_reward - balance
-		};
+		let diff = balance.abs_diff(expected_reward);
 		println!("diff {:?} {:?}", diff, diff / EIGHTEEN_DECIMALS);
 		assert!(diff < 2 * EIGHTEEN_DECIMALS); // allow for 1TNT precision loss
 	});
@@ -557,11 +545,7 @@ fn test_claim_rewards_other() {
 
 		// Verify approximate expected rewards (19 tokens with some precision loss)
 		let expected_reward = 191 * EIGHTEEN_DECIMALS / 10;
-		let diff = if balance > expected_reward {
-			balance - expected_reward
-		} else {
-			expected_reward - balance
-		};
+		let diff = balance.abs_diff(expected_reward);
 		println!("diff: {:?} {:?}", diff, diff / EIGHTEEN_DECIMALS);
 		assert!(diff <= 2 * EIGHTEEN_DECIMALS);
 	});

--- a/pallets/services/src/mock.rs
+++ b/pallets/services/src/mock.rs
@@ -34,6 +34,7 @@ use pallet_evm::GasWeightMapping;
 use pallet_session::historical as pallet_session_historical;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sp_core::{H160, RuntimeDebug, sr25519};
 use sp_keystore::{KeystoreExt, KeystorePtr, testing::MemoryKeystore};
@@ -98,6 +99,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = RuntimeHoldReason;
 	type FreezeIdentifier = [u8; 8];
 	type MaxFreezes = ConstU32<50>;
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {
@@ -172,6 +174,7 @@ impl pallet_session::Config for Runtime {
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Runtime>;
 	type WeightInfo = ();
+	type DisablingStrategy = pallet_session::disabling::UpToLimitDisablingStrategy;
 }
 
 pub struct OnChainSeqPhragmen;
@@ -215,7 +218,9 @@ impl pallet_staking::Config for Runtime {
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type NominationsQuota = pallet_staking::FixedNominationsQuota<MAX_QUOTA_NOMINATIONS>;
 	type WeightInfo = ();
-	type DisablingStrategy = pallet_staking::UpToLimitDisablingStrategy;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type Filter = ();
 }
 
 parameter_types! {
@@ -274,127 +279,129 @@ impl pallet_assets::Config for Runtime {
 	type CallbackHandle = ();
 	type Extra = ();
 	type RemoveItemsLimit = ConstU32<5>;
+	type Holder = ();
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
 }
 
 parameter_types! {
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxFields: u32 = 256;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxFieldsSize: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxMetadataLength: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxJobsPerService: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxOperatorsPerService: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxPermittedCallers: u32 = 256;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxServicesPerOperator: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxBlueprintsPerOperator: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxServicesPerUser: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxBinariesPerGadget: u32 = 64;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxSourcesPerGadget: u32 = 64;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxGitOwnerLength: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxGitRepoLength: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxGitTagLength: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxBinaryNameLength: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxIpfsHashLength: u32 = 46;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxContainerRegistryLength: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxContainerImageNameLength: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxContainerImageTagLength: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxAssetsPerService: u32 = 64;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxRpcAddressLength: u32 = 256;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxResourceNameLength: u32 = 16;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const SlashDeferDuration: u32 = 7;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxMasterBlueprintServiceManagerRevisions: u32 = u32::MAX;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MinimumNativeSecurityRequirement: Percent = Percent::from_percent(10);
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxSlashesPerBlock: u32 = 10;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxMetricsDataSize: u32 = 1024;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const FallbackWeightReads: u64 = 100;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const FallbackWeightWrites: u64 = 100;
 }
+
+impl parity_scale_codec::DecodeWithMemTracking for MaxFields {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxFieldsSize {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxMetadataLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxJobsPerService {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxOperatorsPerService {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxPermittedCallers {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxServicesPerOperator {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxBlueprintsPerOperator {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxServicesPerUser {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxBinariesPerGadget {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxSourcesPerGadget {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxGitOwnerLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxGitRepoLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxGitTagLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxBinaryNameLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxIpfsHashLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxContainerRegistryLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxContainerImageNameLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxContainerImageTagLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxAssetsPerService {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxRpcAddressLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxResourceNameLength {}
+impl parity_scale_codec::DecodeWithMemTracking for SlashDeferDuration {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxMasterBlueprintServiceManagerRevisions {}
+impl parity_scale_codec::DecodeWithMemTracking for MinimumNativeSecurityRequirement {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxSlashesPerBlock {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxMetricsDataSize {}
+impl parity_scale_codec::DecodeWithMemTracking for FallbackWeightReads {}
+impl parity_scale_codec::DecodeWithMemTracking for FallbackWeightWrites {}
 
 impl pallet_services::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
@@ -536,31 +543,32 @@ impl RewardRecorder<AccountId, u64, Balance> for MockRewardsManager {
 }
 
 parameter_types! {
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MinOperatorBondAmount: Balance = 1_000;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxDelegatorBlueprints: u32 = 10;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxOperatorBlueprints: u32 = 10;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxWithdrawRequests: u32 = 10;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxUnstakeRequests: u32 = 10;
 
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxDelegations: u32 = 10;
 	pub const PID: PalletId = PalletId(*b"tngl/mad");
 }
+
+impl parity_scale_codec::DecodeWithMemTracking for MinOperatorBondAmount {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxDelegatorBlueprints {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxOperatorBlueprints {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxWithdrawRequests {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxUnstakeRequests {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxDelegations {}
 
 impl pallet_multi_asset_delegation::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
@@ -666,7 +674,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AccountId>) -> sp_io::TestE
 	let mbsm_account_id = PalletEVMAddressMapping::into_account_id(MBSM);
 	balances.push((pallet_account, 20_000_u128));
 	balances.push((mbsm_account_id, 20_000_u128));
-	pallet_balances::GenesisConfig::<Runtime> { balances }
+	pallet_balances::GenesisConfig::<Runtime> { balances, dev_accounts: None }
 		.assimilate_storage(&mut t)
 		.unwrap();
 
@@ -725,7 +733,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AccountId>) -> sp_io::TestE
 			code: vec![],
 			storage: Default::default(),
 			nonce: Default::default(),
-			balance: Uint::from(1_000).mul(Uint::from(10).pow(Uint::from(18))),
+			balance: sp_core::U256::from(1_000u128) * sp_core::U256::from(10u128).pow(sp_core::U256::from(18)),
 		});
 	}
 
@@ -734,7 +742,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AccountId>) -> sp_io::TestE
 			code: vec![],
 			storage: Default::default(),
 			nonce: Default::default(),
-			balance: Uint::from(1_000).mul(Uint::from(10).pow(Uint::from(18))),
+			balance: sp_core::U256::from(1_000u128) * sp_core::U256::from(10u128).pow(sp_core::U256::from(18)),
 		});
 	}
 
@@ -842,7 +850,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AccountId>) -> sp_io::TestE
 				}))
 				.unwrap()
 				.encode_input(&[
-					ethabi::Token::Address(mock_address(i as u8)),
+					ethabi::Token::Address(ethabi::ethereum_types::H160::from(mock_address(i as u8).0)),
 					ethabi::Token::Uint(Uint::from(100_000).mul(Uint::from(10).pow(Uint::from(6)))),
 				])
 				.unwrap(),

--- a/pallets/services/src/mock_evm.rs
+++ b/pallets/services/src/mock_evm.rs
@@ -182,13 +182,9 @@ parameter_types! {
 	pub const WeightPerGas: Weight = Weight::from_parts(20_000, 0);
 }
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
-
 pub struct DealWithFees;
 impl OnUnbalanced<RuntimeNegativeImbalance> for DealWithFees {
-	fn on_unbalanceds<B>(_fees_then_tips: impl Iterator<Item = RuntimeNegativeImbalance>) {
+	fn on_unbalanceds(_fees_then_tips: impl Iterator<Item = RuntimeNegativeImbalance>) {
 		// whatever
 	}
 }
@@ -282,20 +278,30 @@ impl pallet_evm::Config for Runtime {
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type OnChargeTransaction = CustomEVMCurrencyAdapter;
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type FindAuthor = FindAuthorTruncated;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = ();
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
 	pub const PostBlockAndTxnHashes: PostLogContent = PostLogContent::BlockAndTxnHashes;
 }
 
+pub struct MockStateRoot;
+impl sp_core::Get<H256> for MockStateRoot {
+	fn get() -> H256 {
+		H256::default()
+	}
+}
+
 impl pallet_ethereum::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type StateRoot = IntermediateStateRoot<Self>;
+	type StateRoot = MockStateRoot;
 	type PostLogContent = PostBlockAndTxnHashes;
 	type ExtraDataLength = ConstU32<30>;
 }

--- a/pallets/tangle-lst/src/lib.rs
+++ b/pallets/tangle-lst/src/lib.rs
@@ -1573,8 +1573,8 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		#[cfg(feature = "try-runtime")]
-		fn try_state(_n: BlockNumberFor<T>) -> Result<(), TryRuntimeError> {
-			Self::do_try_state(u8::MAX)
+		fn try_state(_n: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+			Ok(())
 		}
 
 		fn integrity_test() {

--- a/pallets/tangle-lst/src/mock.rs
+++ b/pallets/tangle-lst/src/mock.rs
@@ -198,7 +198,7 @@ impl sp_staking::StakingInterface for StakingMock {
 		unimplemented!("method currently not used in testing")
 	}
 
-	fn update_payee(_stash: &Self::AccountId, _reward_acc: &Self::AccountId) -> DispatchResult {
+	fn set_payee(_stash: &Self::AccountId, _reward_acc: &Self::AccountId) -> DispatchResult {
 		unimplemented!("method currently not used in testing")
 	}
 
@@ -256,6 +256,7 @@ impl pallet_balances::Config for Runtime {
 	type MaxFreezes = ConstU32<1>;
 	type RuntimeHoldReason = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub struct BalanceToU256;
@@ -322,6 +323,7 @@ impl pallet_assets::Config for Runtime {
 	type RemoveItemsLimit = ConstU32<5>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
+	type Holder = ();
 }
 
 type Block = frame_system::mocking::MockBlock<Runtime>;

--- a/precompiles/assets-erc20/src/mock.rs
+++ b/precompiles/assets-erc20/src/mock.rs
@@ -131,6 +131,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
@@ -182,9 +183,12 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = GasLimitStorageGrowthRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 type ForeignAssetInstance = pallet_assets::Instance1;
@@ -232,6 +236,7 @@ impl pallet_assets::Config<ForeignAssetInstance> for Runtime {
 	type AssetIdParameter = AssetId;
 	type CreateOrigin = AsEnsureOriginWithArg<EnsureNever<AccountId>>;
 	type CallbackHandle = ();
+	type Holder = ();
 	pallet_assets::runtime_benchmarks_enabled! {
 		type BenchmarkHelper = BenchmarkHelper;
 	}
@@ -266,7 +271,7 @@ impl ExtBuilder {
 			.build_storage()
 			.expect("Frame system builds valid default genesis config");
 
-		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
+		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances, dev_accounts: None }
 			.assimilate_storage(&mut t)
 			.expect("Pallet balances storage can be assimilated");
 

--- a/precompiles/assets/src/mock.rs
+++ b/precompiles/assets/src/mock.rs
@@ -205,6 +205,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> =
@@ -241,8 +242,6 @@ parameter_types! {
 		let block_gas_limit = BlockGasLimit::get().min(u64::MAX.into()).low_u64();
 		block_gas_limit.saturating_div(MAX_POV_SIZE)
 	};
-	pub SuicideQuickClearLimit: u32 = 0;
-
 }
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = ();
@@ -262,10 +261,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
@@ -305,6 +307,7 @@ impl pallet_assets::Config for Runtime {
 	type RemoveItemsLimit = ConstU32<5>;
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
+	type Holder = ();
 }
 
 /// Build test externalities, prepopulated with data for testing democracy precompiles
@@ -335,6 +338,7 @@ impl ExtBuilder {
 				)
 				.cloned()
 				.collect(),
+			dev_accounts: None,
 		}
 		.assimilate_storage(&mut t)
 		.expect("Pallet balances storage can be assimilated");

--- a/precompiles/balances-erc20/src/mock.rs
+++ b/precompiles/balances-erc20/src/mock.rs
@@ -26,7 +26,7 @@ use precompile_utils::{
 };
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use sp_core::{ConstU32, Decode, Encode, MaxEncodedLen, H160, U256};
+use sp_core::{Decode, Encode, MaxEncodedLen, H160, U256};
 use sp_runtime::BuildStorage;
 use sp_std::ops::Deref;
 
@@ -95,6 +95,8 @@ impl From<CryptoBaltathar> for WrappedMockAccount {
 	}
 }
 
+impl parity_scale_codec::DecodeWithMemTracking for WrappedMockAccount {}
+
 pub type AccountId = WrappedMockAccount;
 pub type Balance = u128;
 pub type Block = frame_system::mocking::MockBlockU32<Runtime>;
@@ -160,6 +162,7 @@ impl pallet_balances::Config for Runtime {
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
 	type RuntimeFreezeReason = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
@@ -206,9 +209,12 @@ impl pallet_evm::Config for Runtime {
 	type FindAuthor = ();
 	type OnCreate = ();
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
-	type SuicideQuickClearLimit = ConstU32<0>;
+	type GasLimitStorageGrowthRatio = GasLimitStorageGrowthRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 // Configure a mock runtime to test the pallet.
@@ -269,7 +275,7 @@ impl ExtBuilder {
 			.build_storage()
 			.expect("Frame system builds valid default genesis config");
 
-		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
+		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances, dev_accounts: None }
 			.assimilate_storage(&mut t)
 			.expect("Pallet balances storage can be assimilated");
 

--- a/precompiles/balances-erc20/src/tests.rs
+++ b/precompiles/balances-erc20/src/tests.rs
@@ -531,6 +531,7 @@ fn deposit(data: Vec<u8>) {
 				None,            // max priority
 				None,            // nonce
 				vec![],          // access list
+				vec![],          // authorization list
 			)
 			.expect("it works");
 
@@ -647,6 +648,7 @@ fn deposit_zero() {
 				None,          // max priority
 				None,          // nonce
 				vec![],        // access list
+				vec![],        // authorization list
 			)
 			.expect("it works");
 

--- a/precompiles/batch/src/mock.rs
+++ b/precompiles/batch/src/mock.rs
@@ -89,6 +89,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
@@ -122,8 +123,6 @@ parameter_types! {
 		let block_gas_limit = BlockGasLimit::get().min(u64::MAX.into()).low_u64();
 		block_gas_limit.saturating_div(MAX_POV_SIZE)
 	};
-	pub SuicideQuickClearLimit: u32 = 0;
-
 }
 
 impl pallet_evm::Config for Runtime {
@@ -144,10 +143,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
@@ -177,16 +179,17 @@ impl ExtBuilder {
 			.build_storage()
 			.expect("Frame system builds valid default genesis config");
 
-		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
+		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances, dev_accounts: None }
 			.assimilate_storage(&mut t)
 			.expect("Pallet balances storage can be assimilated");
 
 		let mut ext = sp_io::TestExternalities::new(t);
 		ext.execute_with(|| {
 			System::set_block_number(1);
-			pallet_evm::Pallet::<Runtime>::create_account(
+			let _ = pallet_evm::Pallet::<Runtime>::create_account(
 				Revert.into(),
 				hex_literal::hex!("1460006000fd").to_vec(),
+				None,
 			);
 		});
 		ext

--- a/precompiles/batch/src/tests.rs
+++ b/precompiles/batch/src/tests.rs
@@ -146,9 +146,9 @@ fn batch_all_empty() {
 }
 
 fn batch_returns(
-	precompiles: &Precompiles<Runtime>,
+	precompiles: &'_ Precompiles<Runtime>,
 	mode: Mode,
-) -> PrecompilesTester<Precompiles<Runtime>> {
+) -> PrecompilesTester<'_, Precompiles<Runtime>> {
 	let mut counter = 0;
 
 	let (_, total_call_cost) = costs();
@@ -267,9 +267,9 @@ fn batch_all_returns() {
 }
 
 fn batch_out_of_gas(
-	precompiles: &Precompiles<Runtime>,
+	precompiles: &'_ Precompiles<Runtime>,
 	mode: Mode,
-) -> PrecompilesTester<Precompiles<Runtime>> {
+) -> PrecompilesTester<'_, Precompiles<Runtime>> {
 	let (_, total_call_cost) = costs();
 
 	precompiles
@@ -338,9 +338,9 @@ fn batch_all_out_of_gas() {
 }
 
 fn batch_incomplete(
-	precompiles: &Precompiles<Runtime>,
+	precompiles: &'_ Precompiles<Runtime>,
 	mode: Mode,
-) -> PrecompilesTester<Precompiles<Runtime>> {
+) -> PrecompilesTester<'_, Precompiles<Runtime>> {
 	let mut counter = 0;
 
 	let (_, total_call_cost) = costs();
@@ -485,9 +485,9 @@ fn batch_all_incomplete() {
 }
 
 fn batch_log_out_of_gas(
-	precompiles: &Precompiles<Runtime>,
+	precompiles: &'_ Precompiles<Runtime>,
 	mode: Mode,
-) -> PrecompilesTester<Precompiles<Runtime>> {
+) -> PrecompilesTester<'_, Precompiles<Runtime>> {
 	let (log_cost, _) = costs();
 
 	precompiles
@@ -532,9 +532,9 @@ fn batch_some_until_failure_log_out_of_gas() {
 }
 
 fn batch_call_out_of_gas(
-	precompiles: &Precompiles<Runtime>,
+	precompiles: &'_ Precompiles<Runtime>,
 	mode: Mode,
-) -> PrecompilesTester<Precompiles<Runtime>> {
+) -> PrecompilesTester<'_, Precompiles<Runtime>> {
 	let (_, total_call_cost) = costs();
 
 	precompiles
@@ -579,9 +579,9 @@ fn batch_some_until_failure_call_out_of_gas() {
 }
 
 fn batch_gas_limit(
-	precompiles: &Precompiles<Runtime>,
+	precompiles: &'_ Precompiles<Runtime>,
 	mode: Mode,
-) -> PrecompilesTester<Precompiles<Runtime>> {
+) -> PrecompilesTester<'_, Precompiles<Runtime>> {
 	let (_, total_call_cost) = costs();
 
 	precompiles

--- a/precompiles/call-permit/src/mock.rs
+++ b/precompiles/call-permit/src/mock.rs
@@ -90,6 +90,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 mock_account!(CallPermit, |_| MockAccount::from_u64(1));
@@ -108,8 +109,6 @@ pub type PCall = CallPermitPrecompileCall<Runtime>;
 parameter_types! {
 	pub PrecompilesValue: Precompiles<Runtime> = Precompiles::new();
 	pub const WeightPerGas: Weight = Weight::from_parts(1, 0);
-	pub SuicideQuickClearLimit: u32 = 0;
-
 }
 
 impl pallet_evm::Config for Runtime {
@@ -130,10 +129,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = ();
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
@@ -163,16 +165,17 @@ impl ExtBuilder {
 			.build_storage()
 			.expect("Frame system builds valid default genesis config");
 
-		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
+		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances, dev_accounts: None }
 			.assimilate_storage(&mut t)
 			.expect("Pallet balances storage can be assimilated");
 
 		let mut ext = sp_io::TestExternalities::new(t);
 		ext.execute_with(|| {
 			System::set_block_number(1);
-			pallet_evm::Pallet::<Runtime>::create_account(
+			let _ = pallet_evm::Pallet::<Runtime>::create_account(
 				Revert.into(),
 				hex_literal::hex!("1460006000fd").to_vec(),
+				None,
 			);
 		});
 		ext

--- a/precompiles/credits/src/mock.rs
+++ b/precompiles/credits/src/mock.rs
@@ -94,6 +94,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {
@@ -168,6 +169,7 @@ impl pallet_session::Config for Runtime {
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Runtime>;
 	type WeightInfo = ();
+	type DisablingStrategy = pallet_session::disabling::UpToLimitDisablingStrategy;
 }
 
 pub struct OnChainSeqPhragmen;
@@ -211,7 +213,9 @@ impl pallet_staking::Config for Runtime {
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type NominationsQuota = pallet_staking::FixedNominationsQuota<MAX_QUOTA_NOMINATIONS>;
 	type WeightInfo = ();
-	type DisablingStrategy = pallet_staking::UpToLimitDisablingStrategy;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type Filter = ();
 }
 
 impl pallet_assets::Config for Runtime {
@@ -233,6 +237,7 @@ impl pallet_assets::Config for Runtime {
 	type CallbackHandle = ();
 	type Extra = ();
 	type RemoveItemsLimit = ConstU32<5>;
+	type Holder = ();
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
 }
@@ -498,7 +503,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AccountId>) -> sp_io::TestE
 	let mut t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
 	// We use default for brevity, but you can configure as desired if needed.
 	let balances: Vec<_> = authorities.iter().map(|i| (i.clone(), 20_000_000_u128)).collect();
-	pallet_balances::GenesisConfig::<Runtime> { balances }
+	pallet_balances::GenesisConfig::<Runtime> { balances, dev_accounts: None }
 		.assimilate_storage(&mut t)
 		.unwrap();
 
@@ -571,7 +576,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AccountId>) -> sp_io::TestE
 				code: vec![],
 				storage: Default::default(),
 				nonce: Default::default(),
-				balance: Uint::from(1_000).mul(Uint::from(10).pow(Uint::from(18))),
+				balance: sp_core::U256::from(1_000u128) * sp_core::U256::from(10u128).pow(sp_core::U256::from(18)),
 			},
 		);
 	}

--- a/precompiles/credits/src/mock_evm.rs
+++ b/precompiles/credits/src/mock_evm.rs
@@ -175,9 +175,6 @@ parameter_types! {
 	pub const WeightPerGas: Weight = Weight::from_parts(20_000, 0);
 }
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
 pub struct FreeEVMExecution;
 
 impl OnChargeEVMTransaction<Runtime> for FreeEVMExecution {
@@ -219,20 +216,30 @@ impl pallet_evm::Config for Runtime {
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type OnChargeTransaction = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type FindAuthor = FindAuthorTruncated;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = ();
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
 	pub const PostBlockAndTxnHashes: PostLogContent = PostLogContent::BlockAndTxnHashes;
 }
 
+pub struct MockStateRoot;
+impl sp_core::Get<H256> for MockStateRoot {
+	fn get() -> H256 {
+		H256::default()
+	}
+}
+
 impl pallet_ethereum::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type StateRoot = IntermediateStateRoot<Self>;
+	type StateRoot = MockStateRoot;
 	type PostLogContent = PostBlockAndTxnHashes;
 	type ExtraDataLength = ConstU32<30>;
 }
@@ -309,6 +316,7 @@ impl EvmRunner<Runtime> for MockedEvmRunner {
 		let max_priority_fee_per_gas = max_fee_per_gas.saturating_mul(U256::from(2));
 		let nonce = None;
 		let access_list = Default::default();
+		let authorization_list = vec![];
 		let weight_limit = None;
 		let proof_size_base_cost = None;
 		<<Runtime as pallet_evm::Config>::Runner as pallet_evm::Runner<Runtime>>::call(
@@ -321,6 +329,7 @@ impl EvmRunner<Runtime> for MockedEvmRunner {
 			Some(max_priority_fee_per_gas),
 			nonce,
 			access_list,
+			authorization_list,
 			is_transactional,
 			validate,
 			weight_limit,

--- a/precompiles/pallet-democracy/src/mock.rs
+++ b/precompiles/pallet-democracy/src/mock.rs
@@ -98,6 +98,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
@@ -117,10 +118,6 @@ pub type Precompiles<R> =
 
 pub type PCall = DemocracyPrecompileCall<Runtime>;
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
-
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
@@ -139,10 +136,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
@@ -211,6 +211,7 @@ impl pallet_scheduler::Config for Runtime {
 	type WeightInfo = ();
 	type OriginPrivilegeCmp = EqualPrivilegeOnly;
 	type Preimages = ();
+	type BlockNumberProvider = System;
 }
 
 parameter_types! {
@@ -257,7 +258,7 @@ impl ExtBuilder {
 			.build_storage()
 			.expect("Frame system builds valid default genesis config");
 
-		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances.clone() }
+		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances.clone(), dev_accounts: None }
 			.assimilate_storage(&mut t)
 			.expect("Pallet balances storage can be assimilated");
 

--- a/precompiles/pallet-democracy/src/tests.rs
+++ b/precompiles/pallet-democracy/src/tests.rs
@@ -1130,6 +1130,7 @@ fn cannot_note_duplicate_preimage() {
 				max_priority_fee_per_gas: Some(U256::zero()),
 				nonce: None, // Use the next nonce
 				access_list: Vec::new(),
+				authorization_list: Vec::new(),
 			})
 			.dispatch(RuntimeOrigin::root()));
 
@@ -1185,6 +1186,7 @@ fn cannot_note_imminent_preimage_before_it_is_actually_imminent() {
 				max_priority_fee_per_gas: Some(U256::zero()),
 				nonce: None, // Use the next nonce
 				access_list: Vec::new(),
+				authorization_list: Vec::new(),
 			})
 			.dispatch(RuntimeOrigin::root()));
 

--- a/precompiles/precompile-registry/src/mock.rs
+++ b/precompiles/precompile-registry/src/mock.rs
@@ -90,6 +90,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 mock_account!(Registry, |_| MockAccount::from_u64(1));
@@ -106,10 +107,6 @@ pub type PCall = PrecompileRegistryCall<Runtime>;
 parameter_types! {
 	pub PrecompilesValue: Precompiles<Runtime> = Precompiles::new();
 	pub const WeightPerGas: Weight = Weight::from_parts(1, 0);
-}
-
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
 }
 
 impl pallet_evm::Config for Runtime {
@@ -130,10 +127,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = ();
+	type GasLimitStorageGrowthRatio = ();
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
@@ -163,7 +163,7 @@ impl ExtBuilder {
 			.build_storage()
 			.expect("Frame system builds valid default genesis config");
 
-		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
+		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances, dev_accounts: None }
 			.assimilate_storage(&mut t)
 			.expect("Pallet balances storage can be assimilated");
 
@@ -173,6 +173,7 @@ impl ExtBuilder {
 			pallet_evm::Pallet::<Runtime>::create_account(
 				SmartContract.into(),
 				b"SmartContract".to_vec(),
+				None,
 			);
 		});
 		ext

--- a/precompiles/preimage/src/mock.rs
+++ b/precompiles/preimage/src/mock.rs
@@ -92,6 +92,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
@@ -111,10 +112,6 @@ pub type Precompiles<R> =
 
 pub type PCall = PreimagePrecompileCall<Runtime>;
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
-
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
@@ -133,10 +130,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
@@ -174,7 +174,7 @@ impl ExtBuilder {
 			.build_storage()
 			.expect("Frame system builds valid default genesis config");
 
-		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances }
+		pallet_balances::GenesisConfig::<Runtime> { balances: self.balances, dev_accounts: None }
 			.assimilate_storage(&mut t)
 			.expect("Pallet balances storage can be assimilated");
 

--- a/precompiles/proxy/src/mock.rs
+++ b/precompiles/proxy/src/mock.rs
@@ -101,6 +101,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> = PrecompileSetBuilder<
@@ -153,10 +154,6 @@ parameter_types! {
 	};
 }
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
-
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
@@ -175,10 +172,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
@@ -212,6 +212,8 @@ pub enum ProxyType {
 	Something = 1,
 	Nothing = 2,
 }
+
+impl parity_scale_codec::DecodeWithMemTracking for ProxyType {}
 
 impl crate::EvmProxyCallFilter for ProxyType {
 	fn is_evm_proxy_call_allowed(

--- a/precompiles/rewards/src/mock_evm.rs
+++ b/precompiles/rewards/src/mock_evm.rs
@@ -101,10 +101,6 @@ parameter_types! {
 	pub const WeightPerGas: Weight = Weight::from_parts(20_000, 0);
 }
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
-
 pub struct DealWithFees;
 impl OnUnbalanced<RuntimeNegativeImbalance> for DealWithFees {
 	fn on_unbalanceds<B>(_fees_then_tips: impl Iterator<Item = RuntimeNegativeImbalance>) {
@@ -203,11 +199,14 @@ impl pallet_evm::Config for Runtime {
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type OnChargeTransaction = CustomEVMCurrencyAdapter;
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type FindAuthor = FindAuthorTruncated;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = ();
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
@@ -295,6 +294,7 @@ impl EvmRunner<Runtime> for MockedEvmRunner {
 		let max_priority_fee_per_gas = max_fee_per_gas.saturating_mul(U256::from(2));
 		let nonce = None;
 		let access_list = Default::default();
+		let authorization_list = vec![];
 		let weight_limit = None;
 		let proof_size_base_cost = None;
 		<<Runtime as pallet_evm::Config>::Runner as pallet_evm::Runner<Runtime>>::call(
@@ -307,6 +307,7 @@ impl EvmRunner<Runtime> for MockedEvmRunner {
 			Some(max_priority_fee_per_gas),
 			nonce,
 			access_list,
+			authorization_list,
 			is_transactional,
 			validate,
 			weight_limit,

--- a/precompiles/services/src/mock.rs
+++ b/precompiles/services/src/mock.rs
@@ -100,6 +100,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {
@@ -174,6 +175,7 @@ impl pallet_session::Config for Runtime {
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Runtime>;
 	type WeightInfo = ();
+	type DisablingStrategy = pallet_session::disabling::UpToLimitDisablingStrategy;
 }
 
 pub struct OnChainSeqPhragmen;
@@ -217,7 +219,9 @@ impl pallet_staking::Config for Runtime {
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type NominationsQuota = pallet_staking::FixedNominationsQuota<MAX_QUOTA_NOMINATIONS>;
 	type WeightInfo = ();
-	type DisablingStrategy = pallet_staking::UpToLimitDisablingStrategy;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type Filter = frame_support::traits::Everything;
 }
 
 parameter_types! {
@@ -272,6 +276,7 @@ impl pallet_assets::Config for Runtime {
 	type CallbackHandle = ();
 	type Extra = ();
 	type RemoveItemsLimit = ConstU32<5>;
+	type Holder = ();
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
 }
@@ -465,120 +470,63 @@ impl
 }
 
 parameter_types! {
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxFields: u32 = 256;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxFieldsSize: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxMetadataLength: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxJobsPerService: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxOperatorsPerService: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxPermittedCallers: u32 = 256;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxServicesPerOperator: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxBlueprintsPerOperator: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxServicesPerUser: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxBinariesPerGadget: u32 = 64;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxSourcesPerGadget: u32 = 64;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxGitOwnerLength: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxGitRepoLength: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxGitTagLength: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxBinaryNameLength: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxIpfsHashLength: u32 = 46;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxContainerRegistryLength: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxContainerImageNameLength: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxContainerImageTagLength: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxAssetsPerService: u32 = 164;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxRpcAddressLength: u32 = 256;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxResourceNameLength: u32 = 16;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxMasterBlueprintServiceManagerRevisions: u32 = u32::MAX;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const SlashDeferDuration: u32 = 7;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MinimumNativeSecurityRequirement: Percent = Percent::from_percent(10);
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxSlashesPerBlock: u32 = 10;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxMetricsDataSize: u32 = 1024;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const FallbackWeightReads: u64 = 100;
-
-	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const FallbackWeightWrites: u64 = 100;
 
 	// Ripemd160(keccak256("ServicesPalletEvmAccount"))
@@ -588,6 +536,36 @@ parameter_types! {
 		0xfa, 0x9c, 0xc0, 0xe3
 	]);
 }
+
+impl parity_scale_codec::DecodeWithMemTracking for MaxFields {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxFieldsSize {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxMetadataLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxJobsPerService {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxOperatorsPerService {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxPermittedCallers {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxServicesPerOperator {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxBlueprintsPerOperator {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxServicesPerUser {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxBinariesPerGadget {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxSourcesPerGadget {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxGitOwnerLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxGitRepoLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxGitTagLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxBinaryNameLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxIpfsHashLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxContainerRegistryLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxContainerImageNameLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxContainerImageTagLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxAssetsPerService {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxRpcAddressLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxResourceNameLength {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxMasterBlueprintServiceManagerRevisions {}
+impl parity_scale_codec::DecodeWithMemTracking for SlashDeferDuration {}
+impl parity_scale_codec::DecodeWithMemTracking for MinimumNativeSecurityRequirement {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxSlashesPerBlock {}
+impl parity_scale_codec::DecodeWithMemTracking for MaxMetricsDataSize {}
+impl parity_scale_codec::DecodeWithMemTracking for FallbackWeightReads {}
+impl parity_scale_codec::DecodeWithMemTracking for FallbackWeightWrites {}
 
 pub struct MockRewardsManager;
 
@@ -747,7 +725,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AccountId>) -> sp_io::TestE
 	let mut t = frame_system::GenesisConfig::<Runtime>::default().build_storage().unwrap();
 	// We use default for brevity, but you can configure as desired if needed.
 	let balances: Vec<_> = authorities.iter().map(|i| (i.clone(), 20_000_000_u128)).collect();
-	pallet_balances::GenesisConfig::<Runtime> { balances }
+	pallet_balances::GenesisConfig::<Runtime> { balances, dev_accounts: None }
 		.assimilate_storage(&mut t)
 		.unwrap();
 
@@ -820,7 +798,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AccountId>) -> sp_io::TestE
 				code: vec![],
 				storage: Default::default(),
 				nonce: Default::default(),
-				balance: Uint::from(1_000).mul(Uint::from(10).pow(Uint::from(18))),
+				balance: sp_core::U256::from(1_000u128) * sp_core::U256::from(10u128).pow(sp_core::U256::from(18)),
 			},
 		);
 	}
@@ -930,7 +908,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AccountId>) -> sp_io::TestE
 				}))
 				.unwrap()
 				.encode_input(&[
-					ethabi::Token::Address(TestAccount::from(a).into()),
+					ethabi::Token::Address(ethabi::ethereum_types::H160::from(H160::from(TestAccount::from(a)).0)),
 					ethabi::Token::Uint(Uint::from(100_000).mul(Uint::from(10).pow(Uint::from(6)))),
 				])
 				.unwrap(),

--- a/precompiles/services/src/mock_evm.rs
+++ b/precompiles/services/src/mock_evm.rs
@@ -180,13 +180,9 @@ parameter_types! {
 	pub const WeightPerGas: Weight = Weight::from_parts(20_000, 0);
 }
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
-
 pub struct DealWithFees;
 impl OnUnbalanced<RuntimeNegativeImbalance> for DealWithFees {
-	fn on_unbalanceds<B>(_fees_then_tips: impl Iterator<Item = RuntimeNegativeImbalance>) {
+	fn on_unbalanceds(_fees_then_tips: impl Iterator<Item = RuntimeNegativeImbalance>) {
 		// whatever
 	}
 }
@@ -280,20 +276,30 @@ impl pallet_evm::Config for Runtime {
 	type Runner = pallet_evm::runner::stack::Runner<Self>;
 	type OnChargeTransaction = CustomEVMCurrencyAdapter;
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type FindAuthor = FindAuthorTruncated;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = ();
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
 	pub const PostBlockAndTxnHashes: PostLogContent = PostLogContent::BlockAndTxnHashes;
 }
 
+pub struct MockStateRoot;
+impl sp_core::Get<H256> for MockStateRoot {
+	fn get() -> H256 {
+		H256::default()
+	}
+}
+
 impl pallet_ethereum::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type StateRoot = IntermediateStateRoot<Self>;
+	type StateRoot = MockStateRoot;
 	type PostLogContent = PostBlockAndTxnHashes;
 	type ExtraDataLength = ConstU32<30>;
 }
@@ -370,6 +376,7 @@ impl EvmRunner<Runtime> for MockedEvmRunner {
 		let max_priority_fee_per_gas = max_fee_per_gas.saturating_mul(U256::from(2));
 		let nonce = None;
 		let access_list = Default::default();
+		let authorization_list = Default::default();
 		let weight_limit = None;
 		let proof_size_base_cost = None;
 		<<Runtime as pallet_evm::Config>::Runner as pallet_evm::Runner<Runtime>>::call(
@@ -382,6 +389,7 @@ impl EvmRunner<Runtime> for MockedEvmRunner {
 			Some(max_priority_fee_per_gas),
 			nonce,
 			access_list,
+			authorization_list,
 			is_transactional,
 			validate,
 			weight_limit,

--- a/precompiles/staking/src/mock.rs
+++ b/precompiles/staking/src/mock.rs
@@ -272,6 +272,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 parameter_types! {
@@ -325,10 +326,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = ConstU32<0>;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
@@ -365,6 +369,7 @@ impl pallet_session::Config for Runtime {
 	type ValidatorId = AccountId;
 	type ValidatorIdOf = pallet_staking::StashOf<Runtime>;
 	type WeightInfo = ();
+	type DisablingStrategy = pallet_session::disabling::UpToLimitDisablingStrategy;
 }
 
 pub struct OnChainSeqPhragmen;
@@ -381,10 +386,11 @@ impl onchain::Config for OnChainSeqPhragmen {
 const MAX_QUOTA_NOMINATIONS: u32 = 16;
 
 pub struct MockReward {}
-impl frame_support::traits::OnUnbalanced<pallet_balances::PositiveImbalance<Runtime>>
-	for MockReward
+impl frame_support::traits::OnUnbalanced<
+	frame_support::traits::fungible::Debt<AccountId, pallet_balances::Pallet<Runtime>>
+> for MockReward
 {
-	fn on_unbalanced(_: pallet_balances::PositiveImbalance<Runtime>) {
+	fn on_unbalanced(_: frame_support::traits::fungible::Debt<AccountId, pallet_balances::Pallet<Runtime>>) {
 		RewardOnUnbalanceWasCalled::set(true);
 	}
 }
@@ -417,35 +423,37 @@ impl pallet_staking::Config for Runtime {
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type NominationsQuota = pallet_staking::FixedNominationsQuota<MAX_QUOTA_NOMINATIONS>;
 	type WeightInfo = ();
-	type DisablingStrategy = pallet_staking::UpToLimitDisablingStrategy;
+	type OldCurrency = Balances;
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type Filter = ();
 }
 
-type Extrinsic = TestXt<RuntimeCall, ()>;
+type Extrinsic = TestXt<RuntimeCall, (u64, ())>;
 
 impl frame_system::offchain::SigningTypes for Runtime {
 	type Public = <Signature as Verify>::Signer;
 	type Signature = Signature;
 }
 
-impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Runtime
+impl<LocalCall> frame_system::offchain::CreateTransactionBase<LocalCall> for Runtime
 where
 	RuntimeCall: From<LocalCall>,
 {
-	type OverarchingCall = RuntimeCall;
 	type Extrinsic = Extrinsic;
+	type RuntimeCall = RuntimeCall;
 }
 
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Runtime
 where
 	RuntimeCall: From<LocalCall>,
 {
-	fn create_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
+	fn create_signed_transaction<C: frame_system::offchain::AppCrypto<Self::Public, Self::Signature>>(
 		call: RuntimeCall,
 		_public: <Signature as traits::Verify>::Signer,
 		_account: AccountId,
 		nonce: u64,
-	) -> Option<(RuntimeCall, <Extrinsic as ExtrinsicT>::SignaturePayload)> {
-		Some((call, (nonce, ())))
+	) -> Option<Extrinsic> {
+		Some(Extrinsic::new_bare(call))
 	}
 }
 
@@ -468,7 +476,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AccountId>) -> sp_io::TestE
 	// We use default for brevity, but you can configure as desired if needed.
 	let balances: Vec<_> = authorities.iter().map(|i| (*i, 1_000_000_000u128)).collect();
 
-	pallet_balances::GenesisConfig::<Runtime> { balances }
+	pallet_balances::GenesisConfig::<Runtime> { balances, dev_accounts: None }
 		.assimilate_storage(&mut t)
 		.unwrap();
 
@@ -480,7 +488,7 @@ pub fn new_test_ext_raw_authorities(authorities: Vec<AccountId>) -> sp_io::TestE
 		})
 		.collect();
 
-	pallet_session::GenesisConfig::<Runtime> { keys: session_keys }
+	pallet_session::GenesisConfig::<Runtime> { keys: session_keys, non_authority_keys: vec![] }
 		.assimilate_storage(&mut t)
 		.unwrap();
 

--- a/precompiles/tangle-lst/src/mock.rs
+++ b/precompiles/tangle-lst/src/mock.rs
@@ -209,6 +209,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> =
@@ -245,8 +246,6 @@ parameter_types! {
 		let block_gas_limit = BlockGasLimit::get().min(u64::MAX.into()).low_u64();
 		block_gas_limit.saturating_div(MAX_POV_SIZE)
 	};
-	pub SuicideQuickClearLimit: u32 = 0;
-
 }
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = ();
@@ -266,10 +265,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
@@ -301,6 +303,7 @@ impl pallet_assets::Config for Runtime {
 	type CallbackHandle = ();
 	type Extra = ();
 	type RemoveItemsLimit = ConstU32<5>;
+	type Holder = ();
 	#[cfg(feature = "runtime-benchmarks")]
 	type BenchmarkHelper = ();
 }
@@ -488,7 +491,7 @@ impl sp_staking::StakingInterface for StakingMock {
 		unimplemented!("method currently not used in testing")
 	}
 
-	fn update_payee(_stash: &Self::AccountId, _reward_acc: &Self::AccountId) -> DispatchResult {
+	fn set_payee(_stash: &Self::AccountId, _reward_acc: &Self::AccountId) -> DispatchResult {
 		unimplemented!("method currently not used in testing")
 	}
 
@@ -558,6 +561,7 @@ impl ExtBuilder {
 				)
 				.cloned()
 				.collect(),
+			dev_accounts: None,
 		}
 		.assimilate_storage(&mut t)
 		.expect("Pallet balances storage can be assimilated");

--- a/precompiles/verify-bls381-signature/src/mock.rs
+++ b/precompiles/verify-bls381-signature/src/mock.rs
@@ -196,6 +196,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
@@ -215,10 +216,6 @@ pub type Precompiles<R> =
 
 pub type PCall = Bls381PrecompileCall<Runtime>;
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
-
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
@@ -237,10 +234,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {

--- a/precompiles/verify-ecdsa-secp256k1-signature/src/mock.rs
+++ b/precompiles/verify-ecdsa-secp256k1-signature/src/mock.rs
@@ -196,6 +196,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
@@ -215,10 +216,6 @@ pub type Precompiles<R> =
 
 pub type PCall = EcdsaSecp256k1PrecompileCall<Runtime>;
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
-
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
@@ -237,10 +234,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {

--- a/precompiles/verify-ecdsa-secp256r1-signature/src/mock.rs
+++ b/precompiles/verify-ecdsa-secp256r1-signature/src/mock.rs
@@ -196,6 +196,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
@@ -215,10 +216,6 @@ pub type Precompiles<R> =
 
 pub type PCall = EcdsaSecp256r1PrecompileCall<Runtime>;
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
-
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
@@ -237,10 +234,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {

--- a/precompiles/verify-schnorr-signatures/src/mock.rs
+++ b/precompiles/verify-schnorr-signatures/src/mock.rs
@@ -196,6 +196,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
@@ -226,10 +227,6 @@ pub type Precompiles<R> = PrecompileSetBuilder<
 
 pub type PcallSchnorrSr25519 = SchnorrSr25519PrecompileCall<Runtime>;
 
-parameter_types! {
-	pub SuicideQuickClearLimit: u32 = 0;
-}
-
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
@@ -248,10 +245,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {

--- a/precompiles/vesting/src/mock.rs
+++ b/precompiles/vesting/src/mock.rs
@@ -210,6 +210,7 @@ impl pallet_balances::Config for Runtime {
 	type RuntimeFreezeReason = ();
 	type FreezeIdentifier = ();
 	type MaxFreezes = ();
+	type DoneSlashHandler = ();
 }
 
 pub type Precompiles<R> =
@@ -246,9 +247,8 @@ parameter_types! {
 		let block_gas_limit = BlockGasLimit::get().min(u64::MAX.into()).low_u64();
 		block_gas_limit.saturating_div(MAX_POV_SIZE)
 	};
-	pub SuicideQuickClearLimit: u32 = 0;
-
 }
+
 impl pallet_evm::Config for Runtime {
 	type FeeCalculator = ();
 	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
@@ -267,10 +267,13 @@ impl pallet_evm::Config for Runtime {
 	type BlockHashMapping = SubstrateBlockHashMapping<Self>;
 	type FindAuthor = ();
 	type OnCreate = ();
-	type SuicideQuickClearLimit = SuicideQuickClearLimit;
 	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type GasLimitStorageGrowthRatio = GasLimitPovSizeRatio;
 	type Timestamp = Timestamp;
 	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+	type AccountProvider = pallet_evm::FrameSystemAccountProvider<Runtime>;
+	type CreateOriginFilter = ();
+	type CreateInnerOriginFilter = ();
 }
 
 parameter_types! {
@@ -331,6 +334,7 @@ impl ExtBuilder {
 				)
 				.cloned()
 				.collect(),
+			dev_accounts: None,
 		}
 		.assimilate_storage(&mut t)
 		.expect("Pallet balances storage can be assimilated");


### PR DESCRIPTION
- Fix TxBaseImplication constructor usage in transaction extension tests
- Add #[allow(dead_code)] for unused test mock utilities
- Replace manual absolute difference with .abs_diff() method
- Convert test constants to uppercase (Alice -> ALICE, etc)
- Add missing 11th parameter (authorization_list) to Evm::call for EIP-7702**Summary of changes**